### PR TITLE
Unspent outputs / balance logic changes

### DIFF
--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/managers/UnspentOutputProvider.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/managers/UnspentOutputProvider.kt
@@ -1,16 +1,33 @@
 package io.horizontalsystems.bitcoinkit.managers
 
 import io.horizontalsystems.bitcoinkit.core.RealmFactory
+import io.horizontalsystems.bitcoinkit.models.Block
 import io.horizontalsystems.bitcoinkit.models.TransactionOutput
 import io.horizontalsystems.bitcoinkit.transactions.scripts.ScriptType
+import io.realm.RealmResults
+import io.realm.Sort
 
-class UnspentOutputProvider(private val realmFactory: RealmFactory) {
-    fun allUnspentOutputs(): List<TransactionOutput> {
-        realmFactory.realm.use {
-            return it.where(TransactionOutput::class.java)
+class UnspentOutputProvider(private val realmFactory: RealmFactory, private val confirmationsThreshold: Int = 6) {
+
+    fun allUnspentOutputs(): List<TransactionOutput> = allUnspentOutputsAsRealmResults().toList()
+
+    fun allUnspentOutputsAsRealmResults(): RealmResults<TransactionOutput> {
+        realmFactory.realm.use { realm ->
+
+            val lastBlockHeight = realm.where(Block::class.java)
+                    .sort("height", Sort.DESCENDING)
+                    .findFirst()?.height ?: 0
+
+            return realm.where(TransactionOutput::class.java)
                     .isNotNull("publicKey")
                     .notEqualTo("scriptType", ScriptType.UNKNOWN)
                     .isEmpty("inputs")
+                    .beginGroup()
+                    .equalTo("transactions.isOutgoing", true)
+                    .or()
+                    .equalTo("transactions.isOutgoing", false)
+                    .lessThanOrEqualTo("transactions.block.height", lastBlockHeight - confirmationsThreshold + 1)
+                    .endGroup()
                     .findAll()
         }
     }

--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/models/Transaction.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/models/Transaction.kt
@@ -39,6 +39,7 @@ open class Transaction : RealmObject {
     var status: Int = Status.RELAYED
     var block: Block? = null
     var isMine = false
+    var isOutgoing = false
     var segwit = false
 
     constructor()

--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/transactions/TransactionLinker.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/transactions/TransactionLinker.kt
@@ -13,7 +13,10 @@ class TransactionLinker {
 
             if (previousTransaction != null && previousTransaction.outputs.size > input.previousOutputIndex) {
                 input.previousOutput = previousTransaction.outputs[input.previousOutputIndex.toInt()]
-                transaction.isMine = true
+                if (input.previousOutput?.publicKey != null) {
+                    transaction.isMine = true
+                    transaction.isOutgoing = true
+                }
             }
         }
     }

--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/transactions/builder/TransactionBuilder.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/transactions/builder/TransactionBuilder.kt
@@ -25,12 +25,12 @@ class TransactionBuilder {
     private val addressManager: AddressManager
     private val realmFactory: RealmFactory
 
-    constructor(realmFactory: RealmFactory, addressConverter: AddressConverter, wallet: HDWallet, network: Network, addressManager: AddressManager) {
+    constructor(realmFactory: RealmFactory, addressConverter: AddressConverter, wallet: HDWallet, network: Network, addressManager: AddressManager, unspentOutputProvider: UnspentOutputProvider) {
         this.realmFactory = realmFactory
         this.addressConverter = addressConverter
         this.addressManager = addressManager
         this.unspentOutputsSelector = UnspentOutputSelector(TransactionSizeCalculator())
-        this.unspentOutputProvider = UnspentOutputProvider(realmFactory)
+        this.unspentOutputProvider = unspentOutputProvider
         this.scriptBuilder = ScriptBuilder()
         this.inputSigner = InputSigner(wallet, network)
     }


### PR DESCRIPTION
- For incoming transactions use unspent outputs from confirmed incoming transactions only
- For outgoing transactions change outputs should be usable without waiting confirmation

Close  #144 
Close #151 