### PR TITLE
Fix the issue with bitcoin stuck syncing on 100%

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/Peer.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/Peer.kt
@@ -105,6 +105,7 @@ class Peer(
 
     override fun socketConnected(address: InetAddress) {
         peerConnection.sendMessage(VersionMessage(localBestBlockHeight, address, network))
+        timer.restart()
     }
 
     override fun disconnected(e: Exception?) {


### PR DESCRIPTION
There were peers that are socket connected but do not respond with any message. The timer doesn't get started, since it starts only when it receives a message from the remote peer. That is why this type of peers never get timeouted. Starting timer for the first time when we send version message fix it. In a result, these type of peers will be disconnected.

Closes #375