### PR TITLE
Call connectPeersIfRequired() in synchronized way, to fix concurrency

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/PeerGroup.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/PeerGroup.kt
@@ -154,6 +154,7 @@ class PeerGroup(
         }
     }
 
+    @Synchronized
     private fun connectPeersIfRequired() {
         if (!running || !connectionManager.isConnected) {
             return


### PR DESCRIPTION
Close #385