### PR TITLE
Enable nLockTime and disable replace-by-fee (RBF)

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionInput.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionInput.kt
@@ -15,6 +15,9 @@ import io.horizontalsystems.bitcoincore.storage.WitnessConverter
  *  VarInt      InputScriptLength    Script length
  *  Variable    InputScript          Script
  *  4 bytes     InputSeqNumber       Input sequence number (irrelevant unless transaction LockTime is non-zero)
+ *
+ *  Note: In order to enable nLockTime and disable Replace-By-Fee, nSequenceNumber must be set to 0xfffffffe (BIP-125)
+ *
  */
 
 @Entity(primaryKeys = ["previousOutputTxHash", "previousOutputIndex"],
@@ -31,7 +34,7 @@ class TransactionInput(
         val previousOutputTxHash: ByteArray,
         val previousOutputIndex: Long,
         var sigScript: ByteArray = byteArrayOf(),
-        val sequence: Long = 0xffffffff) {
+        val sequence: Long = 0xfffffffe) {
 
     var transactionHash = byteArrayOf()
     var keyHash: ByteArray? = null


### PR DESCRIPTION
- in order to use nLockTime, nSequence must not be max value; also for not marking tx as RBF we should set nSequence to 0xfffffffe.
  refer:
  https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#spending-wallet-policy

Close #416 