### PR TITLE
Fix bug in ConnectionManager

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/ConnectionManager.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/ConnectionManager.kt
@@ -13,7 +13,7 @@ class ConnectionManager(context: Context) {
         fun onConnectionChange(isConnected: Boolean)
     }
 
-    private val executorService = Executors.newCachedThreadPool()
+    private val executorService = Executors.newSingleThreadExecutor()
     private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     var listener: Listener? = null

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
using newCachedThreadPool doesn't guarantee that threads will be executed in FIFO order, used newSingleThreadExecutor instead