### PR TITLE
Handle failed transactions

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bitcoinkit/demo/TransactionsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bitcoinkit/demo/TransactionsFragment.kt
@@ -82,6 +82,7 @@ class ViewHolderTransaction(val containerView: View) : RecyclerView.ViewHolder(c
         } ?: ""
 
         var text = "#$index"
+        text += "\nStatus: ${transactionInfo.status.name}"
         if (transactionInfo is DashTransactionInfo) {
             text += "\nInstant: ${transactionInfo.instantTx.toString().toUpperCase()}"
         }
@@ -109,8 +110,9 @@ class ViewHolderTransaction(val containerView: View) : RecyclerView.ViewHolder(c
 
             if (it.mine) line += " (mine)"
 
-            it.pluginData?.let { pluginData ->
-                (pluginData[HodlerPlugin.id] as? HodlerOutputData)?.let { hodlerData ->
+            if (it.pluginId == HodlerPlugin.id && it.pluginData != null) {
+
+                (it.pluginData as? HodlerOutputData)?.let { hodlerData ->
                     val lockTimeInterval = hodlerData.lockTimeInterval
 
                     hodlerData.approxUnlockTime?.let { lockedUntilApprox ->
@@ -118,7 +120,7 @@ class ViewHolderTransaction(val containerView: View) : RecyclerView.ViewHolder(c
                     }
 
                     line += "\n  * Address: ${hodlerData.addressString}"
-                    line += "\n  * Value: ${hodlerData.value}"
+                    line += "\n  * Value: ${hodlerData.lockedValue}"
                 }
             }
 

--- a/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
+++ b/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
@@ -110,8 +110,8 @@ class BitcoinCashKit : AbstractKit {
         bitcoinCore.addRestoreKeyConverterForBip(Bip.BIP44)
     }
 
-    fun transactions(fromHash: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {
-        return bitcoinCore.transactions(fromHash, limit)
+    fun transactions(fromHash: String? = null, fromTimestamp: Long? = null, limit: Int? = null): Single<List<TransactionInfo>> {
+        return bitcoinCore.transactions(fromHash, fromTimestamp, limit)
     }
 
     companion object {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -173,7 +173,10 @@ class BitcoinCoreBuilder {
         peerHostManager.listener = peerGroup
 
         val transactionSyncer = TransactionSyncer(storage, transactionProcessor, publicKeyManager)
-        val transactionSender = TransactionSender(transactionSyncer, peerGroup)
+        val transactionSendTimer = TransactionSendTimer(60)
+        val transactionSender = TransactionSender(transactionSyncer, peerGroup, storage, transactionSendTimer).apply {
+            transactionSendTimer.listener = this
+        }
 
         val unspentOutputSelector = UnspentOutputSelectorChain()
         val transactionSizeCalculator = TransactionSizeCalculator()

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -276,7 +276,7 @@ class BitcoinCoreBuilder {
 
         bitcoinCore.addPeerSyncListener(SendTransactionsOnPeersSynced(transactionSender))
 
-        val mempoolTransactions = MempoolTransactions(transactionSyncer)
+        val mempoolTransactions = MempoolTransactions(transactionSyncer, transactionSender)
         bitcoinCore.addPeerTaskHandler(mempoolTransactions)
         bitcoinCore.addInventoryItemsHandler(mempoolTransactions)
         bitcoinCore.addPeerGroupListener(mempoolTransactions)

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -173,10 +173,7 @@ class BitcoinCoreBuilder {
         peerHostManager.listener = peerGroup
 
         val transactionSyncer = TransactionSyncer(storage, transactionProcessor, publicKeyManager)
-        val transactionSender = TransactionSender().also {
-            it.peerGroup = peerGroup
-            it.transactionSyncer = transactionSyncer
-        }
+        val transactionSender = TransactionSender(transactionSyncer, peerGroup)
 
         val unspentOutputSelector = UnspentOutputSelectorChain()
         val transactionSizeCalculator = TransactionSizeCalculator()
@@ -280,6 +277,8 @@ class BitcoinCoreBuilder {
         bitcoinCore.addPeerTaskHandler(mempoolTransactions)
         bitcoinCore.addInventoryItemsHandler(mempoolTransactions)
         bitcoinCore.addPeerGroupListener(mempoolTransactions)
+
+        bitcoinCore.addPeerTaskHandler(transactionSender)
 
         bitcoinCore.prependUnspentOutputSelector(UnspentOutputSelector(transactionSizeCalculator, unspentOutputProvider))
         bitcoinCore.prependUnspentOutputSelector(UnspentOutputSelectorSingleNoChange(transactionSizeCalculator, unspentOutputProvider))

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -151,7 +151,7 @@ class BitcoinCoreBuilder {
         val irregularOutputFinder = IrregularOutputFinder(storage)
         val transactionOutputsCache = OutputsCache.create(storage)
         val transactionExtractor = TransactionExtractor(addressConverter, storage, pluginManager)
-        val transactionProcessor = TransactionProcessor(storage, transactionExtractor, transactionOutputsCache, publicKeyManager, irregularOutputFinder, dataProvider)
+        val transactionProcessor = TransactionProcessor(storage, transactionExtractor, transactionOutputsCache, publicKeyManager, irregularOutputFinder, dataProvider, transactionInfoConverter)
 
         val kitStateProvider = KitStateProvider()
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -399,8 +399,8 @@ class BitcoinCore(
         start()
     }
 
-    fun transactions(fromHash: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {
-        return dataProvider.transactions(fromHash, limit)
+    fun transactions(fromHash: String? = null, fromTimestamp: Long? = null, limit: Int? = null): Single<List<TransactionInfo>> {
+        return dataProvider.transactions(fromHash, fromTimestamp, limit)
     }
 
     fun fee(value: Long, address: String? = null, senderPay: Boolean = true, feeRate: Int, pluginData: Map<Byte, IPluginData>): Long {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/BaseTransactionInfoConverter.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/BaseTransactionInfoConverter.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.bitcoincore.core
 import io.horizontalsystems.bitcoincore.extensions.toReversedHex
 import io.horizontalsystems.bitcoincore.models.TransactionAddress
 import io.horizontalsystems.bitcoincore.models.TransactionInfo
+import io.horizontalsystems.bitcoincore.models.TransactionStatus
 import io.horizontalsystems.bitcoincore.storage.FullTransactionInfo
 
 class BaseTransactionInfoConverter(private val pluginManager: PluginManager) {
@@ -63,7 +64,8 @@ class BaseTransactionInfoConverter(private val pluginManager: PluginManager) {
                 amount = amount,
                 fee = fee,
                 blockHeight = fullTransaction.block?.height,
-                timestamp = transaction.timestamp
+                timestamp = transaction.timestamp,
+                status = TransactionStatus.getByCode(transaction.status) ?: TransactionStatus.NEW
         )
     }
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/DataProvider.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/DataProvider.kt
@@ -77,19 +77,18 @@ class DataProvider(private val storage: IStorage, private val unspentOutputProvi
         balanceSubjectDisposable.dispose()
     }
 
-    fun transactions(fromHash: String? = null, limit: Int? = null): Single<List<TransactionInfo>> =
+    fun transactions(fromHash: String? = null, fromTimestamp: Long? = null, limit: Int? = null): Single<List<TransactionInfo>> =
             Single.create { emitter ->
                 var results = listOf<FullTransactionInfo>()
-                if (fromHash != null) {
-                    storage.getTransaction(fromHash.toReversedByteArray())?.let {
+                if (fromHash != null && fromTimestamp != null) {
+                    storage.getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)?.let {
                         results = storage.getFullTransactionInfo(it, limit)
                     }
-                }
-                else {
+                } else {
                     results = storage.getFullTransactionInfo(null, limit)
                 }
 
-                emitter.onSuccess(results.map { transactionInfoConverter.transactionInfo(it)})
+                emitter.onSuccess(results.map { transactionInfoConverter.transactionInfo(it) })
             }
 
     private fun blockInfo(block: Block) = BlockInfo(

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
@@ -103,6 +103,7 @@ interface IStorage {
     fun getSentTransaction(hash: ByteArray): SentTransaction?
     fun addSentTransaction(transaction: SentTransaction)
     fun updateSentTransaction(transaction: SentTransaction)
+    fun deleteSentTransaction(transaction: SentTransaction)
 }
 
 interface ITransactionInfoConverter {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
@@ -73,11 +73,9 @@ interface IStorage {
     fun isRelayedTransactionExists(hash: ByteArray): Boolean
     fun isTransactionExists(hash: ByteArray): Boolean
 
-    fun deleteTransaction(transaction: FullTransaction)
-
     // InvalidTransaction
 
-    fun addInvalidTransaction(transaction: InvalidTransaction)
+    fun moveTransactionToInvalidTransactions(invalidTransactions: List<InvalidTransaction>)
     fun deleteAllInvalidTransactions()
 
     //  Transaction Output
@@ -93,6 +91,7 @@ interface IStorage {
 
     fun getTransactionInputs(transaction: Transaction): List<TransactionInput>
     fun getTransactionInputs(txHash: ByteArray): List<TransactionInput>
+    fun getTransactionInputsByPrevOutputTxHash(txHash: ByteArray): List<TransactionInput>
 
     // PublicKey
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
@@ -64,6 +64,7 @@ interface IStorage {
     fun getFullTransactionInfo(txHash: ByteArray): FullTransactionInfo?
 
     fun getTransaction(hash: ByteArray): Transaction?
+    fun getValidOrInvalidTransaction(hash: ByteArray, timestamp: Long): Transaction?
     fun getTransactionOfOutput(output: TransactionOutput): Transaction?
     fun addTransaction(transaction: FullTransaction)
     fun updateTransaction(transaction: Transaction)

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Interfaces.kt
@@ -73,6 +73,13 @@ interface IStorage {
     fun isRelayedTransactionExists(hash: ByteArray): Boolean
     fun isTransactionExists(hash: ByteArray): Boolean
 
+    fun deleteTransaction(transaction: FullTransaction)
+
+    // InvalidTransaction
+
+    fun addInvalidTransaction(transaction: InvalidTransaction)
+    fun deleteAllInvalidTransactions()
+
     //  Transaction Output
 
     fun getUnspentOutputs(): List<UnspentOutput>
@@ -109,7 +116,7 @@ interface IStorage {
 interface ITransactionInfoConverter {
     var baseConverter: BaseTransactionInfoConverter
 
-    fun transactionInfo(transactionForInfo: FullTransactionInfo): TransactionInfo
+    fun transactionInfo(fullTransactionInfo: FullTransactionInfo): TransactionInfo
 }
 
 interface IInitialSyncApi {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/PluginManager.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/PluginManager.kt
@@ -62,11 +62,11 @@ class PluginManager : IRestoreKeyConverter {
         return plugin.isSpendable(unspentOutput)
     }
 
-    fun parsePluginData(output: TransactionOutput, txTimestamp: Long): Map<Byte, IPluginOutputData>? {
+    fun parsePluginData(output: TransactionOutput, txTimestamp: Long): IPluginOutputData? {
         val plugin = plugins[output.pluginId] ?: return null
 
         return try {
-            mapOf(plugin.id to plugin.parsePluginData(output, txTimestamp))
+            plugin.parsePluginData(output, txTimestamp)
         } catch (e: Exception) {
             null
         }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/TransactionInfoConverter.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/TransactionInfoConverter.kt
@@ -6,7 +6,7 @@ import io.horizontalsystems.bitcoincore.storage.FullTransactionInfo
 class TransactionInfoConverter : ITransactionInfoConverter {
     override lateinit var baseConverter: BaseTransactionInfoConverter
 
-    override fun transactionInfo(transactionForInfo: FullTransactionInfo): TransactionInfo {
-        return baseConverter.transactionInfo(transactionForInfo)
+    override fun transactionInfo(fullTransactionInfo: FullTransactionInfo): TransactionInfo {
+        return baseConverter.transactionInfo(fullTransactionInfo)
     }
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/InvalidTransaction.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/InvalidTransaction.kt
@@ -1,0 +1,25 @@
+package io.horizontalsystems.bitcoincore.models
+
+import android.arch.persistence.room.Entity
+
+@Entity
+class InvalidTransaction : Transaction {
+
+    constructor()
+
+    constructor(transaction: Transaction, serializedTxInfo: String) {
+        hash = transaction.hash
+        blockHash = transaction.blockHash
+        version = transaction.version
+        lockTime = transaction.lockTime
+        timestamp = transaction.timestamp
+        order = transaction.order
+        isMine = transaction.isMine
+        isOutgoing = transaction.isOutgoing
+        segwit = transaction.segwit
+        status = Status.INVALID
+
+        this.serializedTxInfo = serializedTxInfo
+    }
+
+}

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/SentTransaction.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/SentTransaction.kt
@@ -11,6 +11,7 @@ class SentTransaction() {
     var firstSendTime: Long = System.currentTimeMillis()
     var lastSendTime: Long = System.currentTimeMillis()
     var retriesCount: Int = 0
+    var sendSuccess: Boolean = false
 
     constructor(hash: ByteArray) : this() {
         this.hash = hash

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/Transaction.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/Transaction.kt
@@ -27,7 +27,7 @@ import java.util.*
                 deferred = true)
         ])
 
-class Transaction {
+open class Transaction {
 
     var hash: ByteArray = byteArrayOf()
     var blockHash: ByteArray? = null
@@ -40,6 +40,7 @@ class Transaction {
     var isOutgoing = false
     var segwit = false
     var status: Int = Status.RELAYED
+    var serializedTxInfo: String = ""
 
     constructor()
     constructor(version: Int = 0, lockTime: Long = 0) : this() {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionInfo.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionInfo.kt
@@ -10,8 +10,21 @@ open class TransactionInfo(
         val amount: Long,
         val fee: Long?,
         val blockHeight: Int?,
-        val timestamp: Long
+        val timestamp: Long,
+        val status: TransactionStatus
 )
+
+enum class TransactionStatus(val code: Int) {
+    NEW(Transaction.Status.NEW),
+    RELAYED(Transaction.Status.RELAYED),
+    INVALID(Transaction.Status.INVALID);
+
+    companion object {
+        private val values = values()
+
+        fun getByCode(code: Int): TransactionStatus? = values.firstOrNull { it.code == code }
+    }
+}
 
 data class TransactionAddress(
         val address: String,

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionInfo.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionInfo.kt
@@ -1,18 +1,111 @@
 package io.horizontalsystems.bitcoincore.models
 
+import com.eclipsesource.json.Json
+import com.eclipsesource.json.JsonArray
+import com.eclipsesource.json.JsonObject
 import io.horizontalsystems.bitcoincore.core.IPluginOutputData
 
-open class TransactionInfo(
-        val transactionHash: String,
-        val transactionIndex: Int,
-        val from: List<TransactionAddress>,
-        val to: List<TransactionAddress>,
-        val amount: Long,
-        val fee: Long?,
-        val blockHeight: Int?,
-        val timestamp: Long,
-        val status: TransactionStatus
-)
+open class TransactionInfo {
+    var transactionHash: String = ""
+    var transactionIndex: Int = 0
+    var from: List<TransactionAddress> = listOf()
+    var to: List<TransactionAddress> = listOf()
+    var amount: Long = 0
+    var fee: Long? = null
+    var blockHeight: Int? = null
+    var timestamp: Long = 0
+    var status: TransactionStatus = TransactionStatus.NEW
+
+    constructor(transactionHash: String,
+                transactionIndex: Int,
+                from: List<TransactionAddress>,
+                to: List<TransactionAddress>,
+                amount: Long,
+                fee: Long?,
+                blockHeight: Int?,
+                timestamp: Long,
+                status: TransactionStatus) {
+        this.transactionHash = transactionHash
+        this.transactionIndex = transactionIndex
+        this.from = from
+        this.to = to
+        this.amount = amount
+        this.fee = fee
+        this.blockHeight = blockHeight
+        this.timestamp = timestamp
+        this.status = status
+    }
+
+    @Throws
+    constructor(serialized: String) {
+        val jsonObject = Json.parse(serialized).asObject()
+        transactionHash = jsonObject.getString("transactionHash", "")
+        transactionIndex = jsonObject.getInt("transactionIndex", 0)
+        this.from = parseTransactionAddresses(jsonObject.get("from").asArray())
+        this.to = parseTransactionAddresses(jsonObject.get("to").asArray())
+        amount = jsonObject.getLong("amount", 0)
+        fee = jsonObject.get("fee")?.asLong()
+        blockHeight = jsonObject.get("blockHeight")?.asInt()
+        timestamp = jsonObject.getLong("timestamp", 0)
+        val statusCode = jsonObject.getInt("status", Transaction.Status.INVALID)
+        status = TransactionStatus.getByCode(statusCode) ?: TransactionStatus.INVALID
+    }
+
+    private fun parseTransactionAddresses(jsonArray: JsonArray): List<TransactionAddress> {
+        val from = mutableListOf<TransactionAddress>()
+
+        for (address in jsonArray) {
+            val addressObj = address.asObject()
+            val pluginId = if (addressObj.get("pluginId").isNull) null else addressObj.get("pluginId").asString().toByte()
+            val pluginDataString = if (addressObj.get("pluginDataString").isNull) null else addressObj.get("pluginDataString").asString()
+
+            val transactionAddress = TransactionAddress(
+                    address = addressObj.getString("address", ""),
+                    mine = addressObj.getBoolean("mine", false),
+                    pluginId = pluginId,
+                    pluginDataString = pluginDataString)
+
+            from.add(transactionAddress)
+        }
+
+        return from
+    }
+
+    private fun transactionAddressesToJson(addresses: List<TransactionAddress>): JsonArray {
+        val jsonArray = JsonArray()
+        addresses.forEach {
+            val address = JsonObject()
+            address.add("address", it.address)
+            address.add("mine", it.mine)
+            address.add("pluginId", it.pluginId?.toString())
+            address.add("pluginDataString", it.pluginDataString)
+            jsonArray.add(address)
+        }
+
+        return jsonArray
+    }
+
+    protected open fun asJsonObject(): JsonObject {
+        val jsonObject = JsonObject()
+
+        jsonObject.add("transactionHash", transactionHash)
+        jsonObject.add("transactionIndex", transactionIndex)
+        jsonObject.add("from", transactionAddressesToJson(from))
+        jsonObject.add("to", transactionAddressesToJson(to))
+        jsonObject.add("amount", amount)
+        fee?.let { jsonObject.add("fee", it) }
+        blockHeight?.let { jsonObject.add("blockHeight", it) }
+        jsonObject.add("timestamp", timestamp)
+        jsonObject.add("status", status.code)
+
+        return jsonObject
+    }
+
+    fun serialize(): String {
+        return asJsonObject().toString()
+    }
+
+}
 
 enum class TransactionStatus(val code: Int) {
     NEW(Transaction.Status.NEW),
@@ -29,7 +122,9 @@ enum class TransactionStatus(val code: Int) {
 data class TransactionAddress(
         val address: String,
         val mine: Boolean,
-        val pluginData: Map<Byte, IPluginOutputData>?
+        val pluginId: Byte? = null,
+        val pluginData: IPluginOutputData? = null,
+        internal val pluginDataString: String? = null
 )
 
 data class BlockInfo(

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/MempoolTransactions.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/MempoolTransactions.kt
@@ -12,7 +12,7 @@ class MempoolTransactions(var transactionSyncer: TransactionSyncer) : IPeerTaskH
     override fun handleCompletedTask(peer: Peer, task: PeerTask): Boolean {
         return when (task) {
             is RequestTransactionsTask -> {
-                transactionSyncer.handleTransactions(task.transactions)
+                transactionSyncer.handleRelayed(task.transactions)
                 removeFromRequestedTransactions(peer.host, task.transactions.map { it.header.hash })
                 true
             }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/MempoolTransactions.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/MempoolTransactions.kt
@@ -3,9 +3,13 @@ package io.horizontalsystems.bitcoincore.network.peer
 import io.horizontalsystems.bitcoincore.models.InventoryItem
 import io.horizontalsystems.bitcoincore.network.peer.task.PeerTask
 import io.horizontalsystems.bitcoincore.network.peer.task.RequestTransactionsTask
+import io.horizontalsystems.bitcoincore.transactions.TransactionSender
 import io.horizontalsystems.bitcoincore.transactions.TransactionSyncer
 
-class MempoolTransactions(var transactionSyncer: TransactionSyncer) : IPeerTaskHandler, IInventoryItemsHandler, PeerGroup.Listener {
+class MempoolTransactions(
+        private val transactionSyncer: TransactionSyncer,
+        private val transactionSender: TransactionSender
+) : IPeerTaskHandler, IInventoryItemsHandler, PeerGroup.Listener {
 
     private val requestedTransactions = hashMapOf<String, MutableList<ByteArray>>()
 
@@ -14,6 +18,7 @@ class MempoolTransactions(var transactionSyncer: TransactionSyncer) : IPeerTaskH
             is RequestTransactionsTask -> {
                 transactionSyncer.handleRelayed(task.transactions)
                 removeFromRequestedTransactions(peer.host, task.transactions.map { it.header.hash })
+                transactionSender.transactionsRelayed(task.transactions)
                 true
             }
             else -> false

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/MempoolTransactions.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/MempoolTransactions.kt
@@ -3,7 +3,6 @@ package io.horizontalsystems.bitcoincore.network.peer
 import io.horizontalsystems.bitcoincore.models.InventoryItem
 import io.horizontalsystems.bitcoincore.network.peer.task.PeerTask
 import io.horizontalsystems.bitcoincore.network.peer.task.RequestTransactionsTask
-import io.horizontalsystems.bitcoincore.network.peer.task.SendTransactionTask
 import io.horizontalsystems.bitcoincore.transactions.TransactionSyncer
 
 class MempoolTransactions(var transactionSyncer: TransactionSyncer) : IPeerTaskHandler, IInventoryItemsHandler, PeerGroup.Listener {
@@ -15,10 +14,6 @@ class MempoolTransactions(var transactionSyncer: TransactionSyncer) : IPeerTaskH
             is RequestTransactionsTask -> {
                 transactionSyncer.handleTransactions(task.transactions)
                 removeFromRequestedTransactions(peer.host, task.transactions.map { it.header.hash })
-                true
-            }
-            is SendTransactionTask -> {
-                transactionSyncer.handleTransaction(task.transaction)
                 true
             }
             else -> false

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/GetMerkleBlocksTask.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/GetMerkleBlocksTask.kt
@@ -47,6 +47,7 @@ class GetMerkleBlocksTask(
 
         requester?.send(GetDataMessage(items))
         resumeWaiting()
+        resetTimer()
     }
 
     override fun handleTimeout() {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/RequestTransactionsTask.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/RequestTransactionsTask.kt
@@ -20,6 +20,7 @@ class RequestTransactionsTask(hashes: List<ByteArray>) : PeerTask() {
         }
 
         requester?.send(GetDataMessage(items))
+        resetTimer()
     }
 
     override fun handleMessage(message: IMessage): Boolean {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/SendTransactionTask.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/SendTransactionTask.kt
@@ -10,11 +10,16 @@ import io.horizontalsystems.bitcoincore.storage.FullTransaction
 
 class SendTransactionTask(val transaction: FullTransaction) : PeerTask() {
 
+    init {
+        allowedIdleTime = 30
+    }
+
     override val state: String
         get() = "transaction: ${transaction.header.hash.toReversedHex()}"
 
     override fun start() {
         requester?.send(InvMessage(InventoryItem.MSG_TX, transaction.header.hash))
+        resetTimer()
     }
 
     override fun handleMessage(message: IMessage): Boolean {
@@ -28,6 +33,10 @@ class SendTransactionTask(val transaction: FullTransaction) : PeerTask() {
         }
 
         return transactionRequested
+    }
+
+    override fun handleTimeout() {
+        listener?.onTaskCompleted(this)
     }
 
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/CoreDatabase.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/CoreDatabase.kt
@@ -41,7 +41,7 @@ abstract class CoreDatabase : RoomDatabase() {
             return Room.databaseBuilder(context, CoreDatabase::class.java, dbName)
                     .allowMainThreadQueries()
                     .addMigrations(
-                            add_sendSuccess_to_SentTransaction,
+                            add_table_InvalidTransaction,
                             update_transaction_output,
                             update_block_timestamp,
                             add_hasTransaction_to_Block,
@@ -50,9 +50,11 @@ abstract class CoreDatabase : RoomDatabase() {
                     .build()
         }
 
-        private val add_sendSuccess_to_SentTransaction = object : Migration(7, 8) {
+        private val add_table_InvalidTransaction = object : Migration(7, 8) {
             override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `InvalidTransaction` (`hash` BLOB NOT NULL, `blockHash` BLOB, `version` INTEGER NOT NULL, `lockTime` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `order` INTEGER NOT NULL, `isMine` INTEGER NOT NULL, `isOutgoing` INTEGER NOT NULL, `segwit` INTEGER NOT NULL, `status` INTEGER NOT NULL, `serializedTxInfo` TEXT NOT NULL, PRIMARY KEY(`hash`))")
                 database.execSQL("ALTER TABLE SentTransaction ADD COLUMN sendSuccess INTEGER DEFAULT 0 NOT NULL")
+                database.execSQL("ALTER TABLE `Transaction` ADD COLUMN serializedTxInfo TEXT DEFAULT '' NOT NULL")
             }
         }
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/CoreDatabase.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/CoreDatabase.kt
@@ -9,7 +9,7 @@ import android.arch.persistence.room.migration.Migration
 import android.content.Context
 import io.horizontalsystems.bitcoincore.models.*
 
-@Database(version = 7, exportSchema = false, entities = [
+@Database(version = 8, exportSchema = false, entities = [
     BlockchainState::class,
     PeerAddress::class,
     BlockHash::class,
@@ -39,12 +39,19 @@ abstract class CoreDatabase : RoomDatabase() {
             return Room.databaseBuilder(context, CoreDatabase::class.java, dbName)
                     .allowMainThreadQueries()
                     .addMigrations(
+                            add_sendSuccess_to_SentTransaction,
                             update_transaction_output,
                             update_block_timestamp,
                             add_hasTransaction_to_Block,
                             add_connectionTime_to_PeerAddress
                     )
                     .build()
+        }
+
+        private val add_sendSuccess_to_SentTransaction = object : Migration(7, 8) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE SentTransaction ADD COLUMN sendSuccess INTEGER DEFAULT 0 NOT NULL")
+            }
         }
 
         private val update_transaction_output = object : Migration(6, 7) {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/CoreDatabase.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/CoreDatabase.kt
@@ -18,7 +18,8 @@ import io.horizontalsystems.bitcoincore.models.*
     Transaction::class,
     TransactionInput::class,
     TransactionOutput::class,
-    PublicKey::class
+    PublicKey::class,
+    InvalidTransaction::class
 ])
 @TypeConverters(ScriptTypeConverter::class)
 abstract class CoreDatabase : RoomDatabase() {
@@ -32,6 +33,7 @@ abstract class CoreDatabase : RoomDatabase() {
     abstract val input: TransactionInputDao
     abstract val output: TransactionOutputDao
     abstract val publicKey: PublicKeyDao
+    abstract val invalidTransaction: InvalidTransactionDao
 
     companion object {
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/InvalidTransactionDao.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/InvalidTransactionDao.kt
@@ -1,0 +1,18 @@
+package io.horizontalsystems.bitcoincore.storage
+
+import android.arch.persistence.room.Dao
+import android.arch.persistence.room.Insert
+import android.arch.persistence.room.OnConflictStrategy
+import android.arch.persistence.room.Query
+import io.horizontalsystems.bitcoincore.models.InvalidTransaction
+
+@Dao
+interface InvalidTransactionDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(transaction: InvalidTransaction)
+
+    @Query("DELETE FROM InvalidTransaction")
+    fun deleteAll()
+
+}

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/Storage.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/Storage.kt
@@ -342,4 +342,8 @@ open class Storage(protected open val store: CoreDatabase) : IStorage {
         store.sentTransaction.insert(transaction)
     }
 
+    override fun deleteSentTransaction(transaction: SentTransaction) {
+        store.sentTransaction.delete(transaction)
+    }
+
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/Storage.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/Storage.kt
@@ -218,6 +218,10 @@ open class Storage(protected open val store: CoreDatabase) : IStorage {
         return store.transaction.getByHash(hash)
     }
 
+    override fun getValidOrInvalidTransaction(hash: ByteArray, timestamp: Long): Transaction? {
+        return store.transaction.getValidOrInvalidByHashAndTimestamp(hash, timestamp)
+    }
+
     override fun getTransactionOfOutput(output: TransactionOutput): Transaction? {
         return store.transaction.getByHash(output.transactionHash)
     }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionDao.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionDao.kt
@@ -36,6 +36,9 @@ interface TransactionDao {
     @Delete
     fun delete(transaction: Transaction)
 
+    @Query("DELETE FROM `Transaction` WHERE hash=:hash")
+    fun deleteByHash(hash: ByteArray)
+
     @Delete
     fun deleteAll(transactions: List<Transaction>)
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionDao.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionDao.kt
@@ -18,6 +18,9 @@ interface TransactionDao {
     @Query("select * from `Transaction` where hash = :hash")
     fun getByHash(hash: ByteArray): Transaction?
 
+    @Query("select * from (SELECT * FROM `Transaction` UNION SELECT * FROM InvalidTransaction) where hash = :hash and timestamp = :timestamp")
+    fun getValidOrInvalidByHashAndTimestamp(hash: ByteArray, timestamp: Long): Transaction?
+
     @Query("select * from `Transaction` where blockHash = :blockHash")
     fun getBlockTransactions(blockHash: ByteArray): List<Transaction>
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionInputDao.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionInputDao.kt
@@ -14,6 +14,9 @@ interface TransactionInputDao {
     @Delete
     fun deleteAll(inputs: List<TransactionInput>)
 
+    @Query("DELETE FROM TransactionInput WHERE transactionHash = :txHash")
+    fun deleteByTxHash(txHash: ByteArray)
+
     @Query("select * from TransactionInput where transactionHash = :hash")
     fun getTransactionInputs(hash: ByteArray): List<TransactionInput>
 
@@ -24,5 +27,8 @@ interface TransactionInputDao {
          WHERE inputs.transactionHash IN(:txHashes)
     """)
     fun getInputsWithPrevouts(txHashes: List<ByteArray>): List<InputWithPreviousOutput>
+
+    @Query("SELECT * FROM TransactionInput WHERE previousOutputTxHash = :txHash")
+    fun getInputsByPrevOutputTxHash(txHash: ByteArray): List<TransactionInput>
 
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionOutputDao.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionOutputDao.kt
@@ -17,6 +17,9 @@ interface TransactionOutputDao {
     @Delete
     fun deleteAll(outputs: List<TransactionOutput>)
 
+    @Query("DELETE FROM TransactionOutput WHERE transactionHash = :txHash")
+    fun deleteByTxHash(txHash: ByteArray)
+
     @Query("""
         SELECT TransactionOutput.*, PublicKey.*, `Transaction`.*, Block.*
         FROM TransactionOutput

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionProcessor.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionProcessor.kt
@@ -96,8 +96,9 @@ class TransactionProcessor(
         if (invalidTransactionsFullInfo.isEmpty())
             return
 
+        invalidTransactionsFullInfo.forEach { it.header.status = Transaction.Status.INVALID }
+
         val invalidTransactions = invalidTransactionsFullInfo.map { fullTxInfo ->
-            fullTxInfo.header.status = Transaction.Status.INVALID
             val txInfo = txInfoConverter.transactionInfo(fullTxInfo)
             val serializedTxInfo = txInfo.serialize()
             InvalidTransaction(fullTxInfo.header, serializedTxInfo)

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionProcessor.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionProcessor.kt
@@ -7,7 +7,6 @@ import io.horizontalsystems.bitcoincore.core.inTopologicalOrder
 import io.horizontalsystems.bitcoincore.extensions.toReversedHex
 import io.horizontalsystems.bitcoincore.managers.BloomFilterManager
 import io.horizontalsystems.bitcoincore.managers.IIrregularOutputFinder
-import io.horizontalsystems.bitcoincore.managers.IrregularOutputFinder
 import io.horizontalsystems.bitcoincore.managers.PublicKeyManager
 import io.horizontalsystems.bitcoincore.models.Block
 import io.horizontalsystems.bitcoincore.models.Transaction
@@ -85,6 +84,15 @@ class TransactionProcessor(
         if (needToUpdateBloomFilter) {
             throw BloomFilterManager.BloomFilterExpired
         }
+    }
+
+    fun processInvalid(transactionHash: ByteArray) {
+        val transaction = storage.getTransaction(transactionHash) ?: return
+
+        transaction.status = Transaction.Status.INVALID
+        storage.updateTransaction(transaction)
+
+        dataListener.onTransactionsUpdate(updated = listOf(transaction), inserted = listOf(), block = null)
     }
 
     private fun process(transaction: FullTransaction) {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSendTimer.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSendTimer.kt
@@ -4,7 +4,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
-class TransactionSendTimer(private val period: Int) {
+class TransactionSendTimer(private val period: Long) {
 
     interface Listener {
         fun onTimePassed()
@@ -14,12 +14,11 @@ class TransactionSendTimer(private val period: Int) {
 
     private var executor = Executors.newSingleThreadScheduledExecutor()
     private var task: ScheduledFuture<*>? = null
-    private val delay = 0L
 
     @Synchronized
     fun startIfNotRunning() {
         if (task == null) {
-            task = executor.scheduleAtFixedRate({ listener?.onTimePassed() }, delay, period.toLong(), TimeUnit.SECONDS)
+            task = executor.scheduleAtFixedRate({ listener?.onTimePassed() }, period, period, TimeUnit.SECONDS)
         }
     }
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSendTimer.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSendTimer.kt
@@ -1,0 +1,34 @@
+package io.horizontalsystems.bitcoincore.transactions
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+class TransactionSendTimer(private val period: Int) {
+
+    interface Listener {
+        fun onTimePassed()
+    }
+
+    var listener: Listener? = null
+
+    private var executor = Executors.newSingleThreadScheduledExecutor()
+    private var task: ScheduledFuture<*>? = null
+    private val delay = 0L
+
+    @Synchronized
+    fun startIfNotRunning() {
+        if (task == null) {
+            task = executor.scheduleAtFixedRate({ listener?.onTimePassed() }, delay, period.toLong(), TimeUnit.SECONDS)
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        task?.let {
+            it.cancel(true)
+            task = null
+        }
+    }
+
+}

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSender.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSender.kt
@@ -43,6 +43,14 @@ class TransactionSender(
         peerGroup.checkPeersSynced()
     }
 
+    fun transactionsRelayed(transactions: List<FullTransaction>) {
+        transactions.forEach { transaction ->
+            storage.getSentTransaction(transaction.header.hash)?.let { sentTransaction ->
+                storage.deleteSentTransaction(sentTransaction)
+            }
+        }
+    }
+
     private fun getTransactionsToSend(transactions: List<FullTransaction>): List<FullTransaction> {
         return transactions.filter { transaction ->
             storage.getSentTransaction(transaction.header.hash)?.let { sentTransaction ->

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSender.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSender.kt
@@ -95,7 +95,7 @@ class TransactionSender(
         sentTransaction.sendSuccess = true
 
         if (sentTransaction.retriesCount >= maxRetriesCount) {
-            transactionSyncer.handleInvalid(transaction)
+            transactionSyncer.handleInvalid(transaction.header.hash)
             storage.deleteSentTransaction(sentTransaction)
         } else {
             storage.updateSentTransaction(sentTransaction)

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSender.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSender.kt
@@ -1,26 +1,37 @@
 package io.horizontalsystems.bitcoincore.transactions
 
+import io.horizontalsystems.bitcoincore.core.IStorage
+import io.horizontalsystems.bitcoincore.models.SentTransaction
 import io.horizontalsystems.bitcoincore.network.peer.IPeerTaskHandler
 import io.horizontalsystems.bitcoincore.network.peer.Peer
 import io.horizontalsystems.bitcoincore.network.peer.PeerGroup
 import io.horizontalsystems.bitcoincore.network.peer.task.PeerTask
 import io.horizontalsystems.bitcoincore.network.peer.task.SendTransactionTask
+import io.horizontalsystems.bitcoincore.storage.FullTransaction
 
 class TransactionSender(
         private val transactionSyncer: TransactionSyncer,
-        private val peerGroup: PeerGroup
-) : IPeerTaskHandler {
+        private val peerGroup: PeerGroup,
+        private val storage: IStorage,
+        private val timer: TransactionSendTimer,
+        private val maxRetriesCount: Int = 3,
+        private val retriesPeriod: Int = 60
+) : IPeerTaskHandler, TransactionSendTimer.Listener {
 
     fun sendPendingTransactions() {
         try {
             peerGroup.checkPeersSynced()
 
-            peerGroup.someReadyPeers().forEach { peer ->
-                transactionSyncer.getPendingTransactions().forEach { pendingTransaction ->
-                    peer.addTask(SendTransactionTask(pendingTransaction))
-                }
+            val transactions = transactionSyncer.getNewTransactions()
+            if (transactions.isEmpty()) {
+                timer.stop()
+                return
             }
 
+            val transactionsToSend = getTransactionsToSend(transactions)
+            if (transactionsToSend.isNotEmpty()) {
+                send(transactionsToSend, peerGroup.someReadyPeers())
+            }
 
         } catch (e: PeerGroup.Error) {
 //            logger.warning("Handling pending transactions failed with: ${e.message}")
@@ -32,16 +43,72 @@ class TransactionSender(
         peerGroup.checkPeersSynced()
     }
 
+    private fun getTransactionsToSend(transactions: List<FullTransaction>): List<FullTransaction> {
+        return transactions.filter { transaction ->
+            storage.getSentTransaction(transaction.header.hash)?.let { sentTransaction ->
+                sentTransaction.retriesCount < maxRetriesCount && sentTransaction.lastSendTime < System.currentTimeMillis() - retriesPeriod
+            } ?: true
+        }
+    }
+
+    private fun send(transactions: List<FullTransaction>, peers: List<Peer>) {
+        timer.startIfNotRunning()
+
+        transactions.forEach { transaction ->
+            transactionSendStart(transaction)
+
+            peers.forEach { peer ->
+                peer.addTask(SendTransactionTask(transaction))
+            }
+        }
+    }
+
+    private fun transactionSendStart(transaction: FullTransaction) {
+        val sentTransaction = storage.getSentTransaction(transaction.header.hash)
+
+        if (sentTransaction == null) {
+            storage.addSentTransaction(SentTransaction(transaction.header.hash))
+        } else {
+            sentTransaction.lastSendTime = System.currentTimeMillis()
+            sentTransaction.sendSuccess = false
+            storage.updateSentTransaction(sentTransaction)
+        }
+    }
+
+    private fun transactionSendSuccess(transaction: FullTransaction) {
+        val sentTransaction = storage.getSentTransaction(transaction.header.hash)
+
+        if (sentTransaction == null || sentTransaction.sendSuccess) {
+            return
+        }
+
+        sentTransaction.retriesCount++
+        sentTransaction.sendSuccess = true
+
+        if (sentTransaction.retriesCount >= maxRetriesCount) {
+            transactionSyncer.handleInvalid(sentTransaction.hash)
+            storage.deleteSentTransaction(sentTransaction)
+        } else {
+            storage.updateSentTransaction(sentTransaction)
+        }
+    }
+
     // IPeerTaskHandler
 
     override fun handleCompletedTask(peer: Peer, task: PeerTask): Boolean {
         return when (task) {
             is SendTransactionTask -> {
-                transactionSyncer.handleTransaction(task.transaction)
+                transactionSendSuccess(task.transaction)
                 true
             }
             else -> false
         }
+    }
+
+    // TransactionSendTimer.Listener
+
+    override fun onTimePassed() {
+        sendPendingTransactions()
     }
 
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncer.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncer.kt
@@ -34,8 +34,8 @@ class TransactionSyncer(
         return !storage.isRelayedTransactionExists(hash)
     }
 
-    fun handleInvalid(transactionHash: ByteArray) {
-        transactionProcessor.processInvalid(transactionHash)
+    fun handleInvalid(fullTransaction: FullTransaction) {
+        transactionProcessor.processInvalid(fullTransaction)
     }
 
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncer.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncer.kt
@@ -34,8 +34,8 @@ class TransactionSyncer(
         return !storage.isRelayedTransactionExists(hash)
     }
 
-    fun handleInvalid(fullTransaction: FullTransaction) {
-        transactionProcessor.processInvalid(fullTransaction)
+    fun handleInvalid(txHash: ByteArray) {
+        transactionProcessor.processInvalid(txHash)
     }
 
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncer.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncer.kt
@@ -3,16 +3,18 @@ package io.horizontalsystems.bitcoincore.transactions
 import io.horizontalsystems.bitcoincore.core.IStorage
 import io.horizontalsystems.bitcoincore.managers.BloomFilterManager
 import io.horizontalsystems.bitcoincore.managers.PublicKeyManager
-import io.horizontalsystems.bitcoincore.models.SentTransaction
 import io.horizontalsystems.bitcoincore.storage.FullTransaction
 
-class TransactionSyncer(private val storage: IStorage, private val transactionProcessor: TransactionProcessor, private val publicKeyManager: PublicKeyManager) {
+class TransactionSyncer(
+        private val storage: IStorage,
+        private val transactionProcessor: TransactionProcessor,
+        private val publicKeyManager: PublicKeyManager) {
 
-    private val maxRetriesCount: Int = 3
-    private val retriesPeriod: Long = 60 * 1000
-    private val totalRetriesPeriod: Long = 60 * 60 * 24 * 1000
+    fun getNewTransactions(): List<FullTransaction> {
+        return storage.getNewTransactions()
+    }
 
-    fun handleTransactions(transactions: List<FullTransaction>) {
+    fun handleRelayed(transactions: List<FullTransaction>) {
         if (transactions.isEmpty()) return
 
         var needToUpdateBloomFilter = false
@@ -28,34 +30,12 @@ class TransactionSyncer(private val storage: IStorage, private val transactionPr
         }
     }
 
-    fun handleTransaction(sentTransaction: FullTransaction) {
-        val newTransaction = storage.getNewTransaction(sentTransaction.header.hash) ?: return
-        val sntTransaction = storage.getSentTransaction(newTransaction.hash) ?: run {
-            storage.addSentTransaction(SentTransaction(newTransaction.hash))
-
-            return
-        }
-
-        sntTransaction.lastSendTime = System.currentTimeMillis()
-        sntTransaction.retriesCount = sntTransaction.retriesCount + 1
-
-        storage.updateSentTransaction(sntTransaction)
-    }
-
-    fun getPendingTransactions(): List<FullTransaction> {
-        return storage.getNewTransactions().filter { transition ->
-            val sentTransaction = storage.getSentTransaction(transition.header.hash)
-            if (sentTransaction == null) {
-                true
-            } else {
-                sentTransaction.retriesCount < maxRetriesCount &&
-                        sentTransaction.lastSendTime < System.currentTimeMillis() - retriesPeriod &&
-                        sentTransaction.firstSendTime > System.currentTimeMillis() - totalRetriesPeriod
-            }
-        }
-    }
-
     fun shouldRequestTransaction(hash: ByteArray): Boolean {
         return !storage.isRelayedTransactionExists(hash)
     }
+
+    fun handleInvalid(transactionHash: ByteArray) {
+        transactionProcessor.processInvalid(transactionHash)
+    }
+
 }

--- a/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/core/DataProviderTest.kt
+++ b/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/core/DataProviderTest.kt
@@ -22,38 +22,39 @@ object DataProviderTest : Spek({
 
     describe("with `fromHash`") {
         val fromHash = "1234"
+        val fromTimestamp = 1234567L
         val limit = 1
 
         it("gets transaction with given hash") {
-            dataProvider.transactions(fromHash).test().assertOf {
-                verify(storage).getTransaction(fromHash.toReversedByteArray())
+            dataProvider.transactions(fromHash, fromTimestamp).test().assertOf {
+                verify(storage).getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)
             }
         }
 
-        context("when transactions exist with given hash") {
+        context("when transactions exist with given hash and timestamp") {
             val fromTransaction = mock<Transaction>()
 
             beforeEach {
-                whenever(storage.getTransaction(fromHash.toReversedByteArray())).thenReturn(fromTransaction)
+                whenever(storage.getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)).thenReturn(fromTransaction)
             }
 
             it("starts loading transactions from that transaction") {
-                dataProvider.transactions(fromHash, limit).test().assertOf {
-                    verify(storage).getTransaction(fromHash.toReversedByteArray())
+                dataProvider.transactions(fromHash, fromTimestamp, limit).test().assertOf {
+                    verify(storage).getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)
 
                     verify(storage).getFullTransactionInfo(fromTransaction, limit)
                 }
             }
         }
 
-        context("when transactions does not exist with given hash") {
+        context("when transactions does not exist with given hash and timestamp") {
             beforeEach {
-                whenever(storage.getTransaction(fromHash.toReversedByteArray())).thenReturn(null)
+                whenever(storage.getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)).thenReturn(null)
             }
 
-            it("do not fetch transactions with `fromHash`") {
-                dataProvider.transactions(fromHash, limit).test().assertOf {
-                    verify(storage).getTransaction(fromHash.toReversedByteArray())
+            it("do not fetch transactions with `fromHash` and `fromTimestamp`") {
+                dataProvider.transactions(fromHash, fromTimestamp, limit).test().assertOf {
+                    verify(storage).getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)
                     verify(storage, never()).getFullTransactionInfo(null, limit)
                 }
             }

--- a/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionProcessorTest.kt
+++ b/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionProcessorTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.horizontalsystems.bitcoincore.Fixtures
 import io.horizontalsystems.bitcoincore.blocks.IBlockchainDataListener
 import io.horizontalsystems.bitcoincore.core.IStorage
+import io.horizontalsystems.bitcoincore.core.ITransactionInfoConverter
 import io.horizontalsystems.bitcoincore.managers.IIrregularOutputFinder
 import io.horizontalsystems.bitcoincore.managers.PublicKeyManager
 import io.horizontalsystems.bitcoincore.models.Transaction
@@ -29,11 +30,12 @@ object TransactionProcessorTest : Spek({
     val publicKeyManager = mock(PublicKeyManager::class.java)
     val blockchainDataListener = mock(IBlockchainDataListener::class.java)
     val irregularOutputFinder = mock(IIrregularOutputFinder::class.java)
+    val txInfoConverter = mock(ITransactionInfoConverter::class.java)
 
     beforeEachTest {
         fullTransaction = Fixtures.transactionP2PKH
         transaction = fullTransaction.header
-        processor = TransactionProcessor(storage, extractor, outputsCache, publicKeyManager, irregularOutputFinder, blockchainDataListener)
+        processor = TransactionProcessor(storage, extractor, outputsCache, publicKeyManager, irregularOutputFinder, blockchainDataListener, txInfoConverter)
     }
 
     fun transactions(): List<FullTransaction> {

--- a/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncerTest.kt
+++ b/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncerTest.kt
@@ -4,10 +4,8 @@ import com.nhaarman.mockitokotlin2.*
 import io.horizontalsystems.bitcoincore.core.IStorage
 import io.horizontalsystems.bitcoincore.managers.BloomFilterManager
 import io.horizontalsystems.bitcoincore.managers.PublicKeyManager
-import io.horizontalsystems.bitcoincore.models.SentTransaction
 import io.horizontalsystems.bitcoincore.models.Transaction
 import io.horizontalsystems.bitcoincore.storage.FullTransaction
-import org.junit.Assert.assertEquals
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.reset
 import org.spekframework.spek2.Spek
@@ -22,10 +20,6 @@ object TransactionSyncerTest : Spek({
 
     val fullTransaction = mock(FullTransaction::class.java)
     val transaction = mock(Transaction::class.java)
-
-    val maxRetriesCount = 3
-    val retriesPeriod: Long = 60 * 1000
-    val totalRetriesPeriod: Long = 60 * 60 * 24 * 1000
 
     beforeEachTest {
         whenever(transaction.hash).thenReturn(byteArrayOf(1, 2, 3))
@@ -76,139 +70,4 @@ object TransactionSyncerTest : Spek({
         }
     }
 
-    describe("#handleTransaction (sent transaction)") {
-
-        context("when SentTransaction does not exist") {
-            beforeEach {
-                whenever(storage.getNewTransaction(transaction.hash)).thenReturn(transaction)
-                whenever(storage.getSentTransaction(transaction.hash)).thenReturn(null)
-            }
-
-            it("adds new SentTransaction object") {
-                argumentCaptor<SentTransaction>().apply {
-                    syncer.handleTransaction(fullTransaction)
-
-                    verify(storage).addSentTransaction(capture())
-                    firstValue.hash = transaction.hash
-                }
-            }
-        }
-
-        context("when SentTransaction exists") {
-            val sentTransaction = SentTransaction()
-
-            beforeEach {
-                sentTransaction.apply {
-                    hash = transaction.hash
-                    firstSendTime = sentTransaction.firstSendTime - 100
-                    lastSendTime = sentTransaction.lastSendTime - 100
-                }
-
-                whenever(storage.getNewTransaction(transaction.hash)).thenReturn(transaction)
-                whenever(storage.getSentTransaction(transaction.hash)).thenReturn(sentTransaction)
-            }
-
-            it("updates existing SentTransaction object") {
-                argumentCaptor<SentTransaction>().apply {
-                    syncer.handleTransaction(fullTransaction)
-
-                    verify(storage).updateSentTransaction(capture())
-                    firstValue.hash = transaction.hash
-                }
-            }
-        }
-
-        context("when Transaction doesn't exist") {
-            beforeEach {
-                whenever(storage.getNewTransaction(transaction.hash)).thenReturn(null)
-            }
-
-            it("neither adds new nor updates existing") {
-                syncer.handleTransaction(fullTransaction)
-
-                verify(storage, never()).addSentTransaction(any())
-                verify(storage, never()).updateSentTransaction(any())
-            }
-        }
-    }
-
-    describe("#getPendingTransactions") {
-
-        context("when transaction is :NEW") {
-            beforeEach {
-                whenever(storage.getNewTransactions()).thenReturn(listOf(fullTransaction))
-            }
-
-            context("when it wasn't sent") {
-                beforeEach {
-                    whenever(storage.getSentTransaction(transaction.hash)).thenReturn(null)
-                }
-
-                it("returns transaction") {
-                    val transactions = syncer.getPendingTransactions()
-
-                    assertEquals(1, transactions.size)
-                    assertEquals(transaction, transactions[0].header)
-                }
-
-            }
-
-            context("when it was sent") {
-                val sentTransaction = SentTransaction()
-
-                beforeEach {
-                    sentTransaction.apply {
-                        hash = transaction.hash
-                        lastSendTime = System.currentTimeMillis() - retriesPeriod - 1
-                        retriesCount = 0
-                    }
-
-                    whenever(storage.getSentTransaction(transaction.hash)).thenReturn(sentTransaction)
-                }
-
-                context("when sent not too many times or too frequently") {
-                    it("returns transaction") {
-                        val transactions = syncer.getPendingTransactions()
-
-                        assertEquals(1, transactions.size)
-                        assertEquals(transaction.hash, transactions[0].header.hash)
-                    }
-                }
-
-                context("when sent too many times") {
-                    it("doesn't return any transaction") {
-                        sentTransaction.retriesCount = maxRetriesCount
-
-                        assertEquals(0, syncer.getPendingTransactions().size)
-                    }
-                }
-
-                context("when sent too often") {
-                    it("doesn't return any transaction") {
-                        sentTransaction.lastSendTime = System.currentTimeMillis()
-
-                        assertEquals(0, syncer.getPendingTransactions().size)
-                    }
-                }
-
-                context("when sent too often in totalRetriesPeriod period") {
-                    it("doesn't return any transaction") {
-                        sentTransaction.firstSendTime = System.currentTimeMillis() - totalRetriesPeriod - 1
-
-                        assertEquals(0, syncer.getPendingTransactions().size)
-                    }
-                }
-            }
-        }
-
-        context("when transaction is not :NEW") {
-            beforeEach {
-                whenever(storage.getNewTransactions()).thenReturn(listOf())
-            }
-
-            it("doesn't return transaction") {
-                assertEquals(0, syncer.getPendingTransactions().size)
-            }
-        }
-    }
 })

--- a/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncerTest.kt
+++ b/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSyncerTest.kt
@@ -41,7 +41,7 @@ object TransactionSyncerTest : Spek({
     describe("handleTransactions") {
         context("when empty array is given") {
             it("doesn't do anything") {
-                syncer.handleTransactions(listOf())
+                syncer.handleRelayed(listOf())
 
                 verify(transactionProcessor, never()).processIncoming(any(), any(), any())
                 verify(publicKeyManager, never()).fillGap()
@@ -58,7 +58,7 @@ object TransactionSyncerTest : Spek({
                 }
 
                 it("fills addresses gap and regenerates bloom filter") {
-                    syncer.handleTransactions(transactions)
+                    syncer.handleRelayed(transactions)
 
                     verify(transactionProcessor).processIncoming(eq(transactions), eq(null), eq(true))
                     verify(publicKeyManager).fillGap()
@@ -67,7 +67,7 @@ object TransactionSyncerTest : Spek({
 
             context("when don't need to update bloom filter") {
                 it("doesn't run address fillGap and doesn't regenerate bloom filter") {
-                    syncer.handleTransactions(transactions)
+                    syncer.handleRelayed(transactions)
 
                     verify(transactionProcessor).processIncoming(eq(transactions), eq(null), eq(true))
                     verify(publicKeyManager, never()).fillGap()

--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
@@ -127,8 +127,8 @@ class BitcoinKit : AbstractKit {
         }
     }
 
-    fun transactions(fromHash: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {
-        return bitcoinCore.transactions(fromHash, limit)
+    fun transactions(fromHash: String? = null, fromTimestamp: Long? = null, limit: Int? = null): Single<List<TransactionInfo>> {
+        return bitcoinCore.transactions(fromHash, fromTimestamp, limit)
     }
 
     companion object {

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.60'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
@@ -182,8 +182,8 @@ class DashKit : AbstractKit, IInstantTransactionDelegate, BitcoinCore.Listener {
         bitcoinCore.prependUnspentOutputSelector(UnspentOutputSelectorSingleNoChange(calculator, confirmedUnspentOutputProvider))
     }
 
-    fun transactions(fromHash: String? = null, limit: Int? = null): Single<List<DashTransactionInfo>> {
-        return bitcoinCore.transactions(fromHash, limit).map {
+    fun transactions(fromHash: String? = null, fromTimestamp: Long, limit: Int? = null): Single<List<DashTransactionInfo>> {
+        return bitcoinCore.transactions(fromHash, fromTimestamp, limit).map {
             it.mapNotNull { it as? DashTransactionInfo }
         }
     }

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/InstantSend.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/InstantSend.kt
@@ -86,7 +86,7 @@ class InstantSend(
     }
 
     private fun handleTransactions(transactions: List<FullTransaction>) {
-        transactionSyncer.handleTransactions(transactions)
+        transactionSyncer.handleRelayed(transactions)
 
         for (transaction in transactions) {
             transactionLockVoteHandler.handle(transaction)

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/core/DashTransactionInfoConverter.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/core/DashTransactionInfoConverter.kt
@@ -20,7 +20,8 @@ class DashTransactionInfoConverter(private val instantTransactionManager: Instan
                 txInfo.fee,
                 txInfo.blockHeight,
                 txInfo.timestamp,
-                instantTransactionManager.isTransactionInstant(transactionForInfo.header.hash)
+                instantTransactionManager.isTransactionInstant(transactionForInfo.header.hash),
+                txInfo.status
         )
     }
 }

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/core/DashTransactionInfoConverter.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/core/DashTransactionInfoConverter.kt
@@ -2,6 +2,10 @@ package io.horizontalsystems.dashkit.core
 
 import io.horizontalsystems.bitcoincore.core.BaseTransactionInfoConverter
 import io.horizontalsystems.bitcoincore.core.ITransactionInfoConverter
+import io.horizontalsystems.bitcoincore.extensions.toHexString
+import io.horizontalsystems.bitcoincore.models.InvalidTransaction
+import io.horizontalsystems.bitcoincore.models.Transaction
+import io.horizontalsystems.bitcoincore.models.TransactionStatus
 import io.horizontalsystems.bitcoincore.storage.FullTransactionInfo
 import io.horizontalsystems.dashkit.instantsend.InstantTransactionManager
 import io.horizontalsystems.dashkit.models.DashTransactionInfo
@@ -9,8 +13,17 @@ import io.horizontalsystems.dashkit.models.DashTransactionInfo
 class DashTransactionInfoConverter(private val instantTransactionManager: InstantTransactionManager) : ITransactionInfoConverter {
     override lateinit var baseConverter: BaseTransactionInfoConverter
 
-    override fun transactionInfo(transactionForInfo: FullTransactionInfo): DashTransactionInfo {
-        val txInfo = baseConverter.transactionInfo(transactionForInfo)
+    override fun transactionInfo(fullTransactionInfo: FullTransactionInfo): DashTransactionInfo {
+        val transaction = fullTransactionInfo.header
+
+        if (transaction.status == Transaction.Status.INVALID) {
+            (transaction as? InvalidTransaction)?.let {
+                return getInvalidTransactionInfo(it)
+            }
+        }
+
+        val txInfo = baseConverter.transactionInfo(fullTransactionInfo)
+
         return DashTransactionInfo(
                 txInfo.transactionHash,
                 txInfo.transactionIndex,
@@ -20,8 +33,28 @@ class DashTransactionInfoConverter(private val instantTransactionManager: Instan
                 txInfo.fee,
                 txInfo.blockHeight,
                 txInfo.timestamp,
-                instantTransactionManager.isTransactionInstant(transactionForInfo.header.hash),
-                txInfo.status
+                txInfo.status,
+                instantTransactionManager.isTransactionInstant(fullTransactionInfo.header.hash)
         )
     }
+
+    private fun getInvalidTransactionInfo(transaction: InvalidTransaction): DashTransactionInfo {
+        return try {
+            DashTransactionInfo(transaction.serializedTxInfo)
+        } catch (ex: Exception) {
+            DashTransactionInfo(
+                    transactionHash = transaction.hash.toHexString(),
+                    transactionIndex = transaction.order,
+                    timestamp = transaction.timestamp,
+                    status = TransactionStatus.INVALID,
+                    from = listOf(),
+                    to = listOf(),
+                    amount = 0,
+                    fee = 0,
+                    blockHeight = null,
+                    instantTx = false
+            )
+        }
+    }
+
 }

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/models/DashTransactionInfo.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/models/DashTransactionInfo.kt
@@ -1,18 +1,39 @@
 package io.horizontalsystems.dashkit.models
 
+import com.eclipsesource.json.Json
+import com.eclipsesource.json.JsonObject
 import io.horizontalsystems.bitcoincore.models.TransactionAddress
 import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.models.TransactionStatus
 
-class DashTransactionInfo(
-        transactionHash: String,
-        transactionIndex: Int,
-        from: List<TransactionAddress>,
-        to: List<TransactionAddress>,
-        amount: Long,
-        fee: Long?,
-        blockHeight: Int?,
-        timestamp: Long,
-        var instantTx: Boolean = false,
-        status: TransactionStatus
-) : TransactionInfo(transactionHash, transactionIndex, from, to, amount, fee, blockHeight, timestamp, status)
+class DashTransactionInfo : TransactionInfo {
+
+    var instantTx: Boolean = false
+
+    constructor(transactionHash: String,
+                transactionIndex: Int,
+                from: List<TransactionAddress>,
+                to: List<TransactionAddress>,
+                amount: Long,
+                fee: Long?,
+                blockHeight: Int?,
+                timestamp: Long,
+                status: TransactionStatus,
+                instantTx: Boolean
+    ) : super(transactionHash, transactionIndex, from, to, amount, fee, blockHeight, timestamp, status) {
+        this.instantTx = instantTx
+    }
+
+    @Throws
+    constructor(serialized: String) : super(serialized) {
+        val jsonObject = Json.parse(serialized).asObject()
+        this.instantTx = jsonObject["instantTx"].asBoolean()
+    }
+
+    override fun asJsonObject(): JsonObject {
+        val jsonObject = super.asJsonObject()
+        jsonObject["instantTx"] = instantTx
+        return jsonObject
+    }
+
+}

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/models/DashTransactionInfo.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/models/DashTransactionInfo.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.dashkit.models
 
 import io.horizontalsystems.bitcoincore.models.TransactionAddress
 import io.horizontalsystems.bitcoincore.models.TransactionInfo
+import io.horizontalsystems.bitcoincore.models.TransactionStatus
 
 class DashTransactionInfo(
         transactionHash: String,
@@ -12,5 +13,6 @@ class DashTransactionInfo(
         fee: Long?,
         blockHeight: Int?,
         timestamp: Long,
-        var instantTx: Boolean = false
-) : TransactionInfo(transactionHash, transactionIndex, from, to, amount, fee, blockHeight, timestamp)
+        var instantTx: Boolean = false,
+        status: TransactionStatus
+) : TransactionInfo(transactionHash, transactionIndex, from, to, amount, fee, blockHeight, timestamp, status)

--- a/hodler/src/main/kotlin/io/horizontalsystems/hodler/HodlerOutputData.kt
+++ b/hodler/src/main/kotlin/io/horizontalsystems/hodler/HodlerOutputData.kt
@@ -2,21 +2,22 @@ package io.horizontalsystems.hodler
 
 import io.horizontalsystems.bitcoincore.core.IPluginOutputData
 
-class HodlerOutputData(val lockTimeInterval: LockTimeInterval, val addressString: String) : IPluginOutputData {
+class HodlerOutputData(val lockTimeInterval: LockTimeInterval,
+                       val addressString: String,
+                       val lockedValue: Long) : IPluginOutputData {
+
     var approxUnlockTime: Long? = null
-    var value: Long? = null
 
     fun serialize(): String {
-        return listOf(lockTimeInterval.serialize(), addressString).joinToString("|")
+        return listOf(lockTimeInterval.serialize(), addressString, lockedValue).joinToString("|")
     }
 
     companion object {
         fun parse(serialized: String?): HodlerOutputData {
-            val (lockTimeIntervalStr, addressString) = checkNotNull(serialized?.split("|"))
+            val (lockTimeIntervalStr, addressString, valueStr) = checkNotNull(serialized?.split("|"))
 
             val lockTimeInterval = checkNotNull(LockTimeInterval.deserialize(lockTimeIntervalStr))
-
-            return HodlerOutputData(lockTimeInterval, addressString)
+            return HodlerOutputData(lockTimeInterval, addressString, valueStr.toLong())
         }
     }
 }

--- a/hodler/src/main/kotlin/io/horizontalsystems/hodler/HodlerPlugin.kt
+++ b/hodler/src/main/kotlin/io/horizontalsystems/hodler/HodlerPlugin.kt
@@ -62,7 +62,7 @@ class HodlerPlugin(
             val addressString = addressConverter.convert(pubkeyHash, ScriptType.P2PKH).string
 
             output.pluginId = id
-            output.pluginData = HodlerOutputData(lockTimeInterval, addressString).serialize()
+            output.pluginData = HodlerOutputData(lockTimeInterval, addressString, output.value).serialize()
 
             storage.getPublicKeyByKeyOrKeyHash(pubkeyHash)?.let { pubkey ->
                 output.redeemScript = redeemScript
@@ -88,9 +88,6 @@ class HodlerPlugin(
         // The median time is 6 blocks earlier which is approximately equal to 1 hour.
         // Here we add 1 hour to show the time when this UTXO will be spendable
         hodlerData.approxUnlockTime = hodlerData.lockTimeInterval.valueInSeconds + txTimestamp + 3600
-
-        // Output value needed to show how much amount is locked
-        hodlerData.value = output.value
 
         return hodlerData
     }


### PR DESCRIPTION
Transactions are marked invalid after 3 send attempts. An attempt to send transactions is counted if SendTransaction task is completed (either by sending "tx" message in response to "getdata" message, or by timeout of 30 seconds). If SendTransaction task was not created or there was some immediate error that failed that task, then transaction send attempt is not counted.
Invalid transactions are stored in separate "InvalidTransaction" table and joined with main "Transaction" table when getting the list of transactions
For pagination timestamp of transaction is needed, since now there may be invalid transactions with the same hashes
