### PR TITLE
Fix BCH initial restore

### DIFF
--- a/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
+++ b/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
@@ -14,11 +14,13 @@ import io.horizontalsystems.bitcoincore.blocks.BlockMedianTimeHelper
 import io.horizontalsystems.bitcoincore.blocks.validators.LegacyDifficultyAdjustmentValidator
 import io.horizontalsystems.bitcoincore.core.Bip
 import io.horizontalsystems.bitcoincore.extensions.toReversedByteArray
+import io.horizontalsystems.bitcoincore.managers.Bip44RestoreKeyConverter
 import io.horizontalsystems.bitcoincore.managers.InsightApi
 import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.network.Network
 import io.horizontalsystems.bitcoincore.storage.CoreDatabase
 import io.horizontalsystems.bitcoincore.storage.Storage
+import io.horizontalsystems.bitcoincore.utils.Base58AddressConverter
 import io.horizontalsystems.bitcoincore.utils.CashAddressConverter
 import io.horizontalsystems.bitcoincore.utils.PaymentAddressParser
 import io.horizontalsystems.hdwalletkit.Mnemonic
@@ -66,7 +68,7 @@ class BitcoinCashKit : AbstractKit {
 
         network = when (networkType) {
             NetworkType.MainNet -> {
-                initialSyncUrl = "https://blockdozer.com/api"
+                initialSyncUrl = "https://bch.coin.space/api"
                 MainNetBitcoinCash()
             }
             NetworkType.TestNet -> {
@@ -93,6 +95,8 @@ class BitcoinCashKit : AbstractKit {
         //  extending bitcoinCore
 
         val bech32 = CashAddressConverter(network.addressSegwitHrp)
+        val base58 = Base58AddressConverter(network.addressVersion ,network.addressScriptVersion)
+
         bitcoinCore.prependAddressConverter(bech32)
 
         if (networkType == NetworkType.MainNet) {
@@ -108,7 +112,9 @@ class BitcoinCashKit : AbstractKit {
             bitcoinCore.addBlockValidator(EDAValidator(maxTargetBits, blockHelper, network.bip44CheckpointBlock.height, BlockMedianTimeHelper(storage)))
         }
 
-        bitcoinCore.addRestoreKeyConverterForBip(Bip.BIP44)
+        bitcoinCore.addRestoreKeyConverter(Bip44RestoreKeyConverter(base58))
+        //bitcoinCore.add(restoreKeyConverter: Bip44RestoreKeyConverter(addressConverter: base58))
+
     }
 
     fun transactions(fromUid: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {

--- a/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
+++ b/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
@@ -12,7 +12,6 @@ import io.horizontalsystems.bitcoincore.BitcoinCore.SyncMode
 import io.horizontalsystems.bitcoincore.BitcoinCoreBuilder
 import io.horizontalsystems.bitcoincore.blocks.BlockMedianTimeHelper
 import io.horizontalsystems.bitcoincore.blocks.validators.LegacyDifficultyAdjustmentValidator
-import io.horizontalsystems.bitcoincore.core.Bip
 import io.horizontalsystems.bitcoincore.extensions.toReversedByteArray
 import io.horizontalsystems.bitcoincore.managers.Bip44RestoreKeyConverter
 import io.horizontalsystems.bitcoincore.managers.InsightApi
@@ -113,8 +112,6 @@ class BitcoinCashKit : AbstractKit {
         }
 
         bitcoinCore.addRestoreKeyConverter(Bip44RestoreKeyConverter(base58))
-        //bitcoinCore.add(restoreKeyConverter: Bip44RestoreKeyConverter(addressConverter: base58))
-
     }
 
     fun transactions(fromUid: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -334,8 +334,8 @@ class BitcoinCore(
         return this
     }
 
-    fun addRestoreKeyConverterForBip(bip: Bip) {
-        restoreKeyConverterChain.add(bip.restoreKeyConverter(addressConverter))
+    fun addRestoreKeyConverter(keyConverter: IRestoreKeyConverter) {
+        restoreKeyConverterChain.add(keyConverter)
     }
 
     fun addMessageParser(messageParser: IMessageParser): BitcoinCore {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Bip.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Bip.kt
@@ -26,9 +26,4 @@ enum class Bip {
             BIP84 -> HDWallet.Purpose.BIP84
         }
 
-    fun restoreKeyConverter(addressConverter: AddressConverterChain) = when (this) {
-        BIP44 -> Bip44RestoreKeyConverter(addressConverter)
-        BIP49 -> Bip49RestoreKeyConverter(addressConverter)
-        BIP84 -> Bip84RestoreKeyConverter(addressConverter)
-    }
 }

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Bip.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/Bip.kt
@@ -1,10 +1,6 @@
 package io.horizontalsystems.bitcoincore.core
 
-import io.horizontalsystems.bitcoincore.managers.Bip44RestoreKeyConverter
-import io.horizontalsystems.bitcoincore.managers.Bip49RestoreKeyConverter
-import io.horizontalsystems.bitcoincore.managers.Bip84RestoreKeyConverter
 import io.horizontalsystems.bitcoincore.transactions.scripts.ScriptType
-import io.horizontalsystems.bitcoincore.utils.AddressConverterChain
 import io.horizontalsystems.hdwalletkit.HDWallet
 
 enum class Bip {

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
@@ -6,7 +6,6 @@ import io.horizontalsystems.bitcoincore.AbstractKit
 import io.horizontalsystems.bitcoincore.BitcoinCore
 import io.horizontalsystems.bitcoincore.BitcoinCore.SyncMode
 import io.horizontalsystems.bitcoincore.BitcoinCoreBuilder
-import io.horizontalsystems.bitcoincore.core.Bip
 import io.horizontalsystems.bitcoincore.extensions.hexToByteArray
 import io.horizontalsystems.bitcoincore.managers.*
 import io.horizontalsystems.bitcoincore.models.BalanceInfo

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
@@ -8,10 +8,7 @@ import io.horizontalsystems.bitcoincore.BitcoinCore.SyncMode
 import io.horizontalsystems.bitcoincore.BitcoinCoreBuilder
 import io.horizontalsystems.bitcoincore.core.Bip
 import io.horizontalsystems.bitcoincore.extensions.hexToByteArray
-import io.horizontalsystems.bitcoincore.managers.BlockValidatorHelper
-import io.horizontalsystems.bitcoincore.managers.InsightApi
-import io.horizontalsystems.bitcoincore.managers.UnspentOutputSelector
-import io.horizontalsystems.bitcoincore.managers.UnspentOutputSelectorSingleNoChange
+import io.horizontalsystems.bitcoincore.managers.*
 import io.horizontalsystems.bitcoincore.models.BalanceInfo
 import io.horizontalsystems.bitcoincore.models.BlockInfo
 import io.horizontalsystems.bitcoincore.models.TransactionInfo
@@ -19,6 +16,7 @@ import io.horizontalsystems.bitcoincore.network.Network
 import io.horizontalsystems.bitcoincore.storage.CoreDatabase
 import io.horizontalsystems.bitcoincore.storage.Storage
 import io.horizontalsystems.bitcoincore.transactions.TransactionSizeCalculator
+import io.horizontalsystems.bitcoincore.utils.Base58AddressConverter
 import io.horizontalsystems.bitcoincore.utils.MerkleBranch
 import io.horizontalsystems.bitcoincore.utils.PaymentAddressParser
 import io.horizontalsystems.dashkit.core.DashTransactionInfoConverter
@@ -155,8 +153,8 @@ class DashKit : AbstractKit, IInstantTransactionDelegate, BitcoinCore.Listener {
         bitcoinCore.addPeerSyncListener(masternodeSyncer)
         bitcoinCore.addPeerGroupListener(masternodeSyncer)
 
-        bitcoinCore.addRestoreKeyConverterForBip(Bip.BIP44)
-
+        val base58AddressConverter = Base58AddressConverter(network.addressVersion, network.addressScriptVersion)
+        bitcoinCore.addRestoreKeyConverter(Bip44RestoreKeyConverter(base58AddressConverter))
 
         val singleHasher = SingleSha256Hasher()
         val bls = BLS()


### PR DESCRIPTION
-  Replace insight-api host (blockdozer) to coin.space.
-  Refactor keyConverter method implementation