### PR TITLE
Fix incorrect transaction size calculation

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/UnspentOutputSelectorSingleNoChange.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/UnspentOutputSelectorSingleNoChange.kt
@@ -19,7 +19,7 @@ class UnspentOutputSelectorSingleNoChange(private val calculator: TransactionSiz
         //  try to find 1 unspent output with exactly matching value
         for (unspentOutput in unspentOutputs) {
             val output = unspentOutput.output
-            val fee = calculator.transactionSize(listOf(output.scriptType), listOf(outputType), pluginDataOutputSize) * feeRate
+            val fee = calculator.transactionSize(listOf(output), listOf(outputType), pluginDataOutputSize) * feeRate
 
             val recipientValue = if (senderPay) value else value - fee
             val sentValue = if (senderPay) value + fee else value

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/builder/InputSetter.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/builder/InputSetter.kt
@@ -57,14 +57,7 @@ class InputSetter(
         }
 
         // Calculate fee
-        var transactionSize = transactionSizeCalculator.transactionSize(listOf(unspentOutput.output.scriptType), listOf(mutableTransaction.recipientAddress.scriptType), 0)
-        unspentOutput.output.signatureScriptFunction?.let { signatureScriptFunction ->
-            val emptySignature = ByteArray(transactionSizeCalculator.signatureLength)
-            val emptyPublicKey = ByteArray(transactionSizeCalculator.pubKeyLength)
-
-            transactionSize += signatureScriptFunction(listOf(emptySignature, emptyPublicKey)).size
-        }
-
+        val transactionSize = transactionSizeCalculator.transactionSize(listOf(unspentOutput.output), listOf(mutableTransaction.recipientAddress.scriptType), 0)
         val fee = transactionSize * feeRate
 
         if (unspentOutput.output.value < fee) {

--- a/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/core/DataProviderTest.kt
+++ b/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/core/DataProviderTest.kt
@@ -1,7 +1,6 @@
 package io.horizontalsystems.bitcoincore.core
 
 import com.nhaarman.mockitokotlin2.*
-import io.horizontalsystems.bitcoincore.extensions.toReversedByteArray
 import io.horizontalsystems.bitcoincore.managers.UnspentOutputProvider
 import io.horizontalsystems.bitcoincore.models.Transaction
 import org.spekframework.spek2.Spek
@@ -21,13 +20,12 @@ object DataProviderTest : Spek({
     }
 
     describe("with `fromHash`") {
-        val fromHash = "1234"
-        val fromTimestamp = 1234567L
+        val fromUid = "1234"
         val limit = 1
 
         it("gets transaction with given hash") {
-            dataProvider.transactions(fromHash, fromTimestamp).test().assertOf {
-                verify(storage).getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)
+            dataProvider.transactions(fromUid).test().assertOf {
+                verify(storage).getValidOrInvalidTransaction(fromUid)
             }
         }
 
@@ -35,12 +33,12 @@ object DataProviderTest : Spek({
             val fromTransaction = mock<Transaction>()
 
             beforeEach {
-                whenever(storage.getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)).thenReturn(fromTransaction)
+                whenever(storage.getValidOrInvalidTransaction(fromUid)).thenReturn(fromTransaction)
             }
 
             it("starts loading transactions from that transaction") {
-                dataProvider.transactions(fromHash, fromTimestamp, limit).test().assertOf {
-                    verify(storage).getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)
+                dataProvider.transactions(fromUid, limit).test().assertOf {
+                    verify(storage).getValidOrInvalidTransaction(fromUid)
 
                     verify(storage).getFullTransactionInfo(fromTransaction, limit)
                 }
@@ -49,12 +47,12 @@ object DataProviderTest : Spek({
 
         context("when transactions does not exist with given hash and timestamp") {
             beforeEach {
-                whenever(storage.getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)).thenReturn(null)
+                whenever(storage.getValidOrInvalidTransaction(fromUid)).thenReturn(null)
             }
 
             it("do not fetch transactions with `fromHash` and `fromTimestamp`") {
-                dataProvider.transactions(fromHash, fromTimestamp, limit).test().assertOf {
-                    verify(storage).getValidOrInvalidTransaction(fromHash.toReversedByteArray(), fromTimestamp)
+                dataProvider.transactions(fromUid, limit).test().assertOf {
+                    verify(storage).getValidOrInvalidTransaction(fromUid)
                     verify(storage, never()).getFullTransactionInfo(null, limit)
                 }
             }

--- a/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSizeCalculatorTest.kt
+++ b/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/transactions/TransactionSizeCalculatorTest.kt
@@ -1,5 +1,7 @@
 package io.horizontalsystems.bitcoincore.transactions
 
+import io.horizontalsystems.bitcoincore.models.TransactionOutput
+import io.horizontalsystems.bitcoincore.transactions.scripts.ScriptType
 import io.horizontalsystems.bitcoincore.transactions.scripts.ScriptType.*
 import org.junit.Assert.assertEquals
 import org.spekframework.spek2.Spek
@@ -10,16 +12,20 @@ object TransactionSizeCalculatorTest : Spek({
 
     describe("calculate size") {
 
+        fun outputs(scriptTypes: List<ScriptType>): List<TransactionOutput> {
+            return scriptTypes.map { TransactionOutput().apply { this.scriptType = it } }
+        }
+
         it("transactionSize") {
             assertEquals(10, calculator.transactionSize(listOf(), listOf(), 0))
-            assertEquals(192, calculator.transactionSize(listOf(P2PKH), listOf(P2PKH), 0))
-            assertEquals(306, calculator.transactionSize(listOf(P2PKH, P2PK), listOf(P2PKH), 0))
-            assertEquals(303, calculator.transactionSize(listOf(P2PKH, P2PK), listOf(P2WPKH), 0))      // 2-in 1-out legacy tx with witness output
-            assertEquals(350, calculator.transactionSize(listOf(P2PKH, P2PK), listOf(P2PKH, P2PK), 0)) // 2-in 2-out legacy tx
+            assertEquals(192, calculator.transactionSize(outputs(listOf(P2PKH)), listOf(P2PKH), 0))
+            assertEquals(306, calculator.transactionSize(outputs(listOf(P2PKH, P2PK)), listOf(P2PKH), 0))
+            assertEquals(303, calculator.transactionSize(outputs(listOf(P2PKH, P2PK)), listOf(P2WPKH), 0))      // 2-in 1-out legacy tx with witness output
+            assertEquals(350, calculator.transactionSize(outputs(listOf(P2PKH, P2PK)), listOf(P2PKH, P2PK), 0)) // 2-in 2-out legacy tx
 
-            assertEquals(113, calculator.transactionSize(listOf(P2WPKH), listOf(P2PKH), 0))        // 1-in 1-out witness tx
-            assertEquals(136, calculator.transactionSize(listOf(P2WPKHSH), listOf(P2PKH), 0))      // 1-in 1-out (sh) witness tx
-            assertEquals(261, calculator.transactionSize(listOf(P2WPKH, P2PKH), listOf(P2PKH), 0)) // 2-in 1-out witness tx
+            assertEquals(113, calculator.transactionSize(outputs(listOf(P2WPKH)), listOf(P2PKH), 0))        // 1-in 1-out witness tx
+            assertEquals(136, calculator.transactionSize(outputs(listOf(P2WPKHSH)), listOf(P2PKH), 0))      // 1-in 1-out (sh) witness tx
+            assertEquals(261, calculator.transactionSize(outputs(listOf(P2WPKH, P2PKH)), listOf(P2PKH), 0)) // 2-in 1-out witness tx
         }
 
         it("inputSize") {


### PR DESCRIPTION
- add signatureLength + pubKeyLength + redeemScriptLength to inputs size for locked transactions