### PR TITLE
Get transaction inputs and outputs by order of insertion

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionInputDao.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionInputDao.kt
@@ -17,7 +17,7 @@ interface TransactionInputDao {
     @Query("DELETE FROM TransactionInput WHERE transactionHash = :txHash")
     fun deleteByTxHash(txHash: ByteArray)
 
-    @Query("select * from TransactionInput where transactionHash = :hash")
+    @Query("select * from TransactionInput where transactionHash = :hash order by rowId")
     fun getTransactionInputs(hash: ByteArray): List<TransactionInput>
 
     @Query("select * from TransactionInput where transactionHash IN (:hashes)")

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionOutputDao.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/storage/TransactionOutputDao.kt
@@ -34,7 +34,7 @@ interface TransactionOutputDao {
     @Query("select * from TransactionOutput where transactionHash = :previousOutputTxHash and `index` = :previousOutputIndex limit 1")
     fun getPreviousOutput(previousOutputTxHash: ByteArray, previousOutputIndex: Int): TransactionOutput?
 
-    @Query("select * from TransactionOutput where transactionHash = :hash")
+    @Query("select * from TransactionOutput where transactionHash = :hash order by rowId")
     fun getByHash(hash: ByteArray): List<TransactionOutput>
 
     @Query("select * from TransactionOutput where publicKeyPath = :path")


### PR DESCRIPTION
- for tx signature to be created correctly inputs and outputs should be in correct serialized order