### PR TITLE
Update BCH API restore URL to *.bitcoin.com

### DIFF
--- a/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
+++ b/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
@@ -67,7 +67,7 @@ class BitcoinCashKit : AbstractKit {
 
         network = when (networkType) {
             NetworkType.MainNet -> {
-                initialSyncUrl = "https://bch.coin.space/api"
+                initialSyncUrl = "https://cashexplorer.bitcoin.com/api"
                 MainNetBitcoinCash()
             }
             NetworkType.TestNet -> {

--- a/bitcoincore/build.gradle
+++ b/bitcoincore/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     // JSON
     implementation 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
 
+    // OkHTTPClient3
+    implementation 'com.squareup.okhttp3:okhttp:4.4.0'
+
     // HDWallet Kit
     api 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/InsightApi.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/InsightApi.kt
@@ -19,7 +19,7 @@ class InsightApi(host: String) : IInitialSyncApi {
 
     private fun fetchTransactions(addrs: List<String>, txs: MutableList<TransactionItem>, from: Int, to: Int) {
         val joinedAddresses = addrs.joinToString(",")
-        val json = apiManager.get("addrs/$joinedAddresses/txs?from=$from&to=$to").asObject()
+        val json = apiManager.doOkHttpGet(false, "addrs/$joinedAddresses/txs?from=$from&to=$to").asObject()
 
         val totalItems = json["totalItems"].asInt()
         val receivedTo = json["to"].asInt()

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/utils/NetworkUtils.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/utils/NetworkUtils.kt
@@ -1,7 +1,14 @@
 package io.horizontalsystems.bitcoincore.utils
 
+import android.annotation.SuppressLint
 import io.horizontalsystems.bitcoincore.extensions.toHexString
+import okhttp3.OkHttpClient
 import java.net.*
+import java.security.SecureRandom
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.*
 
 object NetworkUtils {
 
@@ -43,4 +50,40 @@ object NetworkUtils {
             return Socket()
         }
     }
+
+    @SuppressLint("TrustAllX509TrustManager", "BadHostnameVerifier")
+    fun getUnsafeOkHttpClient(): OkHttpClient {
+        return try {
+            val trustAllCerts = arrayOf<TrustManager>(
+                    object : X509TrustManager {
+                        @Throws(CertificateException::class)
+                        override fun checkClientTrusted(chain: Array<X509Certificate>,
+                                                        authType: String) {
+                        }
+
+                        @Throws(CertificateException::class)
+                        override fun checkServerTrusted(chain: Array<X509Certificate>,
+                                                        authType: String) {
+                        }
+
+                        override fun getAcceptedIssuers(): Array<X509Certificate> {
+                            return arrayOf()
+                        }
+                    }
+            )
+            val sslContext = SSLContext.getInstance("SSL")
+            sslContext.init(null, trustAllCerts, SecureRandom())
+            val sslSocketFactory = sslContext.socketFactory
+            val builder = OkHttpClient.Builder()
+            builder.sslSocketFactory(sslSocketFactory, (trustAllCerts[0] as X509TrustManager))
+            builder.hostnameVerifier(HostnameVerifier { hostname, session -> true })
+            builder.connectTimeout(5000, TimeUnit.MILLISECONDS)
+            builder.readTimeout(60000, TimeUnit.MILLISECONDS)
+            builder.build()
+
+        } catch (e: Exception) {
+            throw RuntimeException(e)
+        }
+    }
+
 }

--- a/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/utils/NetworkUtilsTest.kt
+++ b/bitcoincore/src/test/kotlin/io/horizontalsystems/bitcoincore/utils/NetworkUtilsTest.kt
@@ -1,0 +1,57 @@
+package io.horizontalsystems.bitcoincore.utils
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import java.net.URL
+import javax.net.ssl.SSLHandshakeException
+
+internal class NetworkUtilsTest {
+
+    // System is  Unable to find valid certification path to below URL
+    private val CERT_ERROR_TEST_URL = "https://cashexplorer.bitcoin.com/api/sync/"
+
+    @Test
+    fun testUnsafeHttpRequest() {
+
+        assertDoesNotThrow {
+            doUnsafeHttpRequest()
+        }
+
+        assertThrows(SSLHandshakeException::class.java) { doSafeHttpRequest() }
+        assertThrows(SSLHandshakeException::class.java) { doUrlConnectionRequest() }
+    }
+
+    private fun doSafeHttpRequest() {
+        doOkHttpRequest(OkHttpClient.Builder().build())
+    }
+
+    private fun doUnsafeHttpRequest() {
+        doOkHttpRequest(NetworkUtils.getUnsafeOkHttpClient())
+    }
+
+    private fun doUrlConnectionRequest() {
+        URL(CERT_ERROR_TEST_URL)
+                .openConnection()
+                .apply {
+                    connectTimeout = 5000
+                    readTimeout = 60000
+                    setRequestProperty("Accept", "application/json")
+                }.getInputStream()
+                .use {
+                    //Success
+                }
+    }
+
+    private fun doOkHttpRequest(httpClient: OkHttpClient) {
+        val request = Request.Builder().url(CERT_ERROR_TEST_URL).build()
+
+        return httpClient.newCall(request)
+                .execute()
+                .use {
+                    //success
+                }
+    }
+}


### PR DESCRIPTION
Ref #1899

- Update BCH API restore URL to cashexplorer.bitcoin.com
- Implement connection based SSL all-trust utility (To bypass Cert errors).