### PR TITLE
Resolve dependency conflicts for okHttp3 library.

### DIFF
--- a/bitcoincore/build.gradle
+++ b/bitcoincore/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
 
     // OkHTTPClient3
-    implementation 'com.squareup.okhttp3:okhttp:4.4.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.0.1'
 
     // HDWallet Kit
     api 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'


### PR DESCRIPTION
- Set dependency version for okHttp3 to 4.0.1