### PR TITLE
Update btc testnet restore api url (https).

### DIFF
--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
@@ -70,7 +70,7 @@ class BitcoinKit : AbstractKit {
                 MainNet()
             }
             NetworkType.TestNet -> {
-                initialSyncUrl = "http://btc-testnet.horizontalsystems.xyz/apg"
+                initialSyncUrl = "https://btc-testnet.horizontalsystems.xyz/api"
                 TestNet()
             }
             NetworkType.RegTest -> RegTest()


### PR DESCRIPTION
- Update btc testnet restore API to https.