### PR TITLE
Update room compiler and fix related kapt errors

### DIFF
--- a/bitcoincore/build.gradle
+++ b/bitcoincore/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     // Room
     implementation 'androidx.room:room-runtime:2.2.5'
-    kapt 'androidx.room:room-compiler:2.0.0' // TODO when updating error occurs, need to look into it
+    kapt 'androidx.room:room-compiler:2.2.5'
 
     implementation 'androidx.room:room-rxjava2:2.2.5'
 

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/InvalidTransaction.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/InvalidTransaction.kt
@@ -3,11 +3,9 @@ package io.horizontalsystems.bitcoincore.models
 import androidx.room.Entity
 
 @Entity
-class InvalidTransaction : Transaction {
+class InvalidTransaction() : Transaction() {
 
-    constructor()
-
-    constructor(transaction: Transaction, serializedTxInfo: String) {
+    constructor(transaction: Transaction, serializedTxInfo: String) : this() {
         uid = transaction.uid
         hash = transaction.hash
         blockHash = transaction.blockHash

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/PublicKey.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/PublicKey.kt
@@ -14,10 +14,11 @@ import io.horizontalsystems.bitcoincore.utils.Utils
             Index("scriptHashP2WPKH")
         ])
 
-class PublicKey {
+class PublicKey() {
     var path: String = ""
 
     var account = 0
+
     @ColumnInfo(name = "address_index")
     var index = 0
     var external = true
@@ -30,7 +31,6 @@ class PublicKey {
         return storage.getOutputsOfPublicKey(this).isNotEmpty()
     }
 
-    constructor()
     constructor(account: Int, index: Int, external: Boolean, publicKey: ByteArray, publicKeyHash: ByteArray) : this() {
         this.path = "$account/${if (external) 1 else 0}/$index"
         this.account = account

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/Transaction.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/Transaction.kt
@@ -27,7 +27,7 @@ import java.util.*
                 deferred = true)
         ])
 
-open class Transaction {
+open class Transaction() {
 
     var uid: String = UUID.randomUUID().toString()
 
@@ -45,7 +45,6 @@ open class Transaction {
     var serializedTxInfo: String = ""
     var conflictingTxHash: ByteArray? = null
 
-    constructor()
     constructor(version: Int = 0, lockTime: Long = 0) : this() {
         this.version = version
         this.lockTime = lockTime

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionOutput.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/models/TransactionOutput.kt
@@ -34,7 +34,7 @@ import io.horizontalsystems.bitcoincore.transactions.scripts.ScriptType
                     deferred = true)
         ])
 
-class TransactionOutput {
+class TransactionOutput() {
 
     var value: Long = 0
     var lockingScript: ByteArray = byteArrayOf()
@@ -53,8 +53,7 @@ class TransactionOutput {
     @Ignore
     var signatureScriptFunction: ((List<ByteArray>) -> ByteArray)? = null
 
-    constructor()
-    constructor(value: Long, index: Int, script: ByteArray, type: ScriptType = ScriptType.UNKNOWN, address: String? = null, keyHash: ByteArray? = null, publicKey: PublicKey? = null) {
+    constructor(value: Long, index: Int, script: ByteArray, type: ScriptType = ScriptType.UNKNOWN, address: String? = null, keyHash: ByteArray? = null, publicKey: PublicKey? = null): this() {
         this.value = value
         this.lockingScript = script
         this.index = index


### PR DESCRIPTION
It seems that room compiler with version above 2.0.0 requires entity classes to have a primary constructor if there are more than one constructors. Otherwise it cannot find appropriate constructor and gives compile time error.