### PR TITLE
Get transaction by its hash

### DIFF
--- a/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
+++ b/bitcoincashkit/src/main/kotlin/io/horizontalsystems/bitcoincash/BitcoinCashKit.kt
@@ -18,7 +18,6 @@ import io.horizontalsystems.bitcoincore.blocks.validators.ProofOfWorkValidator
 import io.horizontalsystems.bitcoincore.extensions.toReversedByteArray
 import io.horizontalsystems.bitcoincore.managers.Bip44RestoreKeyConverter
 import io.horizontalsystems.bitcoincore.managers.InsightApi
-import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.network.Network
 import io.horizontalsystems.bitcoincore.storage.CoreDatabase
 import io.horizontalsystems.bitcoincore.storage.Storage
@@ -26,7 +25,6 @@ import io.horizontalsystems.bitcoincore.utils.Base58AddressConverter
 import io.horizontalsystems.bitcoincore.utils.CashAddressConverter
 import io.horizontalsystems.bitcoincore.utils.PaymentAddressParser
 import io.horizontalsystems.hdwalletkit.Mnemonic
-import io.reactivex.Single
 
 class BitcoinCashKit : AbstractKit {
     enum class NetworkType {
@@ -119,10 +117,6 @@ class BitcoinCashKit : AbstractKit {
         bitcoinCore.prependAddressConverter(bech32)
 
         bitcoinCore.addRestoreKeyConverter(Bip44RestoreKeyConverter(base58))
-    }
-
-    fun transactions(fromUid: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {
-        return bitcoinCore.transactions(fromUid, limit)
     }
 
     companion object {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/AbstractKit.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/AbstractKit.kt
@@ -4,10 +4,12 @@ import io.horizontalsystems.bitcoincore.core.IPluginData
 import io.horizontalsystems.bitcoincore.models.BitcoinPaymentData
 import io.horizontalsystems.bitcoincore.models.PublicKey
 import io.horizontalsystems.bitcoincore.models.TransactionDataSortType
+import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.network.Network
 import io.horizontalsystems.bitcoincore.storage.FullTransaction
 import io.horizontalsystems.bitcoincore.storage.UnspentOutput
 import io.horizontalsystems.bitcoincore.transactions.scripts.ScriptType
+import io.reactivex.Single
 
 abstract class AbstractKit {
 
@@ -35,6 +37,14 @@ abstract class AbstractKit {
 
     fun refresh() {
         bitcoinCore.refresh()
+    }
+
+    fun transactions(fromUid: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {
+        return bitcoinCore.transactions(fromUid, limit)
+    }
+
+    fun getTransaction(hash: String): TransactionInfo? {
+        return bitcoinCore.getTransaction(hash)
     }
 
     fun fee(value: Long, address: String? = null, senderPay: Boolean = true, feeRate: Int, pluginData: Map<Byte, IPluginData> = mapOf()): Long {

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -572,6 +572,10 @@ class BitcoinCore(
         return dataProvider.getRawTransaction(transactionHash)
     }
 
+    fun getTransaction(hash: String) : TransactionInfo? {
+        return dataProvider.getTransaction(hash)
+    }
+
     sealed class KitState {
         object Synced : KitState()
         class NotSynced(val exception: Throwable) : KitState()

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/DataProvider.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/core/DataProvider.kt
@@ -99,6 +99,12 @@ class DataProvider(private val storage: IStorage, private val unspentOutputProvi
         }
     }
 
+    fun getTransaction(transactionHash: String): TransactionInfo? {
+        return storage.getFullTransactionInfo(transactionHash.hexToByteArray().reversedArray())?.let {
+            transactionInfoConverter.transactionInfo(it)
+        }
+    }
+
     private fun blockInfo(block: Block) = BlockInfo(
             block.headerHash.toReversedHex(),
             block.height,

--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
@@ -10,7 +10,6 @@ import io.horizontalsystems.bitcoincore.blocks.BlockMedianTimeHelper
 import io.horizontalsystems.bitcoincore.blocks.validators.*
 import io.horizontalsystems.bitcoincore.core.Bip
 import io.horizontalsystems.bitcoincore.managers.*
-import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.network.Network
 import io.horizontalsystems.bitcoincore.storage.CoreDatabase
 import io.horizontalsystems.bitcoincore.storage.Storage
@@ -19,7 +18,6 @@ import io.horizontalsystems.bitcoincore.utils.PaymentAddressParser
 import io.horizontalsystems.bitcoincore.utils.SegwitAddressConverter
 import io.horizontalsystems.hdwalletkit.Mnemonic
 import io.horizontalsystems.hodler.HodlerPlugin
-import io.reactivex.Single
 
 class BitcoinKit : AbstractKit {
     enum class NetworkType {
@@ -134,10 +132,6 @@ class BitcoinKit : AbstractKit {
                 bitcoinCore.addRestoreKeyConverter(Bip84RestoreKeyConverter(bech32AddressConverter))
             }
         }
-    }
-
-    fun transactions(fromUid: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {
-        return bitcoinCore.transactions(fromUid, limit)
     }
 
     companion object {

--- a/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
+++ b/dashkit/src/main/kotlin/io/horizontalsystems/dashkit/DashKit.kt
@@ -193,10 +193,14 @@ class DashKit : AbstractKit, IInstantTransactionDelegate, BitcoinCore.Listener {
         bitcoinCore.prependUnspentOutputSelector(UnspentOutputSelectorSingleNoChange(calculator, confirmedUnspentOutputProvider))
     }
 
-    fun transactions(fromUid: String? = null, limit: Int? = null): Single<List<DashTransactionInfo>> {
-        return bitcoinCore.transactions(fromUid, limit).map {
+    fun dashTransactions(fromUid: String? = null, limit: Int? = null): Single<List<DashTransactionInfo>> {
+        return transactions(fromUid, limit).map {
             it.mapNotNull { it as? DashTransactionInfo }
         }
+    }
+
+    fun getDashTransaction(hash: String): DashTransactionInfo? {
+        return getTransaction(hash) as? DashTransactionInfo
     }
 
     // BitcoinCore.Listener

--- a/litecoinkit/src/main/kotlin/io/horizontalsystems/litecoinkit/LitecoinKit.kt
+++ b/litecoinkit/src/main/kotlin/io/horizontalsystems/litecoinkit/LitecoinKit.kt
@@ -12,7 +12,6 @@ import io.horizontalsystems.bitcoincore.blocks.validators.BlockValidatorSet
 import io.horizontalsystems.bitcoincore.blocks.validators.LegacyTestNetDifficultyValidator
 import io.horizontalsystems.bitcoincore.core.Bip
 import io.horizontalsystems.bitcoincore.managers.*
-import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.network.Network
 import io.horizontalsystems.bitcoincore.storage.CoreDatabase
 import io.horizontalsystems.bitcoincore.storage.Storage
@@ -22,7 +21,6 @@ import io.horizontalsystems.bitcoincore.utils.SegwitAddressConverter
 import io.horizontalsystems.hdwalletkit.Mnemonic
 import io.horizontalsystems.litecoinkit.validators.LegacyDifficultyAdjustmentValidator
 import io.horizontalsystems.litecoinkit.validators.ProofOfWorkValidator
-import io.reactivex.Single
 
 class LitecoinKit : AbstractKit {
     enum class NetworkType {
@@ -134,10 +132,6 @@ class LitecoinKit : AbstractKit {
                 bitcoinCore.addRestoreKeyConverter(Bip84RestoreKeyConverter(bech32AddressConverter))
             }
         }
-    }
-
-    fun transactions(fromUid: String? = null, limit: Int? = null): Single<List<TransactionInfo>> {
-        return bitcoinCore.transactions(fromUid, limit)
     }
 
     companion object {


### PR DESCRIPTION
Method is added in AbstractKit. Dash version of this method added to the DashKit. The existing method `transactions()` is refactored the same way.