### PR TITLE
Fix the issue with sending transaction by setting the correct timeout

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/SendTransactionTask.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/network/peer/task/SendTransactionTask.kt
@@ -7,11 +7,12 @@ import io.horizontalsystems.bitcoincore.network.messages.IMessage
 import io.horizontalsystems.bitcoincore.network.messages.InvMessage
 import io.horizontalsystems.bitcoincore.network.messages.TransactionMessage
 import io.horizontalsystems.bitcoincore.storage.FullTransaction
+import java.util.concurrent.TimeUnit
 
 class SendTransactionTask(val transaction: FullTransaction) : PeerTask() {
 
     init {
-        allowedIdleTime = 30
+        allowedIdleTime = TimeUnit.SECONDS.toMillis(30)
     }
 
     override val state: String


### PR DESCRIPTION
Previously it was set to 30 millis by mistake. So it resulted in the following scenario:

1. We create a SendTransaction task and start it
2. The task sends Inv message
3. After about a sec we check for timeout
4. Task completes itself since there was no incoming GetData message
5. We receive GetData message. But this message is not handled at all, since the task has been already completed
6. Then we retry sending the transaction
7. If we send the Inv message to the same peer it won't respond with GetData message anymore. Most likely the remote peer marks the Inventory as handled.
8. The transaction gets stuck and fails :(

https://github.com/horizontalsystems/unstoppable-wallet-android/issues/3760