### PR TITLE
Update Hd-wallet-kit dependency for public extended key

### DIFF
--- a/bitcoincore/build.gradle
+++ b/bitcoincore/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.5.0'
 
     // HDWallet Kit
-    api 'com.github.horizontalsystems:hd-wallet-kit-android:7a559bd'
+    api 'com.github.horizontalsystems:hd-wallet-kit-android:1642a09'
 
     // Test helpers
     testImplementation 'junit:junit:4.13'


### PR DESCRIPTION
https://github.com/horizontalsystems/unstoppable-wallet-android/issues/4980