### PR TITLE
Ignore incoming pending transactions when sync mode is blockchair

### DIFF
--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCoreBuilder.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCoreBuilder.kt
@@ -344,13 +344,15 @@ class BitcoinCoreBuilder {
         val transactionExtractor = TransactionExtractor(addressConverter, storage, pluginManager, metadataExtractor)
 
         val conflictsResolver = TransactionConflictsResolver(storage)
+        val ignorePendingIncoming = syncMode is BitcoinCore.SyncMode.Blockchair
         val pendingTransactionProcessor = PendingTransactionProcessor(
             storage,
             transactionExtractor,
             publicKeyManager,
             irregularOutputFinder,
             dataProvider,
-            conflictsResolver
+            conflictsResolver,
+            ignorePendingIncoming
         )
         val invalidator = TransactionInvalidator(storage, transactionInfoConverter, dataProvider)
         val blockTransactionProcessor = BlockTransactionProcessor(

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/PendingTransactionProcessor.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/transactions/PendingTransactionProcessor.kt
@@ -9,6 +9,7 @@ import io.horizontalsystems.bitcoincore.extensions.toReversedHex
 import io.horizontalsystems.bitcoincore.managers.BloomFilterManager
 import io.horizontalsystems.bitcoincore.managers.IIrregularOutputFinder
 import io.horizontalsystems.bitcoincore.models.Transaction
+import io.horizontalsystems.bitcoincore.models.TransactionType
 import io.horizontalsystems.bitcoincore.storage.FullTransaction
 import io.horizontalsystems.bitcoincore.transactions.extractors.TransactionExtractor
 
@@ -18,7 +19,8 @@ class PendingTransactionProcessor(
     private val publicKeyManager: IPublicKeyManager,
     private val irregularOutputFinder: IIrregularOutputFinder,
     private val dataListener: IBlockchainDataListener,
-    private val conflictsResolver: TransactionConflictsResolver
+    private val conflictsResolver: TransactionConflictsResolver,
+    private val ignorePendingIncoming: Boolean
 ) {
 
     private val notMineTransactions = HashSet<ByteArray>()
@@ -112,6 +114,9 @@ class PendingTransactionProcessor(
                 }
 
                 resolveConflicts(transaction, updated)
+                if (ignorePendingIncoming && transaction.metadata.type == TransactionType.Incoming) {
+                    continue
+                }
                 storage.addTransaction(transaction)
                 inserted.add(transaction.header)
 


### PR DESCRIPTION
 This is because in blockchair sync mode we don't sync all the blocks after the checkpoint. Instead, we only sync blocks where blockchair says we have a transaction. Thus, if we receive an incoming transaction "A" which is replaced by another transaction "B" (that sends funds to another wallet) in the mempool, we won't receive "B" from blockchair (because it's not related to any of our addresses), and so "A" is left in 'pending' state on our list of transactions. A 'pending' transaction is left forever, and the user may think the funds are still on the way, whereas in fact, they were sent to another wallet.