### PR TITLE
Update Room to Support macOS Builds

### DIFF
--- a/bitcoincashkit/build.gradle
+++ b/bitcoincashkit/build.gradle
@@ -51,9 +51,9 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.2.5'
-    implementation 'androidx.room:room-rxjava2:2.2.5'
-    kapt 'androidx.room:room-compiler:2.2.5'
+    implementation libs.room.runtime
+    implementation libs.room.rxjava2
+    kapt libs.room.compiler
 
     api project(':bitcoincore')
 

--- a/bitcoincore/build.gradle
+++ b/bitcoincore/build.gradle
@@ -62,10 +62,9 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.2.5'
-    kapt 'androidx.room:room-compiler:2.2.5'
-
-    implementation 'androidx.room:room-rxjava2:2.2.5'
+    implementation libs.room.runtime
+    implementation libs.room.rxjava2
+    kapt libs.room.compiler
 
     // For cryptography
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.65'

--- a/bitcoinkit/build.gradle
+++ b/bitcoinkit/build.gradle
@@ -51,9 +51,9 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.2.5'
-    implementation 'androidx.room:room-rxjava2:2.2.5'
-    kapt 'androidx.room:room-compiler:2.2.5'
+    implementation libs.room.runtime
+    implementation libs.room.rxjava2
+    kapt libs.room.compiler
 
     api project(':bitcoincore')
     api project(':hodler')

--- a/dashkit/build.gradle
+++ b/dashkit/build.gradle
@@ -67,9 +67,9 @@ dependencies {
     implementation 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.2.5'
-    implementation 'androidx.room:room-rxjava2:2.2.5'
-    kapt 'androidx.room:room-compiler:2.2.5'
+    implementation libs.room.runtime
+    implementation libs.room.rxjava2
+    kapt libs.room.compiler
 
     api project(':bitcoincore')
     implementation files('libs/dashj-bls-0.15.3.jar')

--- a/ecashkit/build.gradle
+++ b/ecashkit/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-javalite:3.22.2'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.2.5'
-    implementation 'androidx.room:room-rxjava2:2.2.5'
-    kapt 'androidx.room:room-compiler:2.2.5'
+    implementation libs.room.runtime
+    implementation libs.room.rxjava2
+    kapt libs.room.compiler
 
     api project(':bitcoincore')
     api project(':bitcoincashkit')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+roomRuntime = "2.4.3"
+
+[libraries]
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomRuntime" }
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }
+room-rxjava2 = { module = "androidx.room:room-rxjava2", version.ref = "roomRuntime" }
+
+[plugins]

--- a/litecoinkit/build.gradle
+++ b/litecoinkit/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     // Room
-    implementation 'androidx.room:room-runtime:2.2.5'
-    implementation 'androidx.room:room-rxjava2:2.2.5'
-    kapt 'androidx.room:room-compiler:2.2.5'
+    implementation libs.room.runtime
+    implementation libs.room.rxjava2
+    kapt libs.room.compiler
 
     api project(':bitcoincore')
     api project(':hodler')


### PR DESCRIPTION
This PR updates the Room dependency to version 2.4.3 to resolve build issues on macOS. The previous version is not compatible with MacOS Apple Silicon (M1, M2,M3,M4).

Changes:

    Updated Room to version 2.4.3.

    Verified successful build and execution on macOS Apple Silicon.

Reason:
Developers using macOS were encountering build failures due to incompatibilities in the older library version. This update ensures consistent development experience across platforms.