### PR TITLE
Add new DNS seeds for Bitcoin and Litecoin MainNets

### DIFF
--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/MainNet.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/MainNet.kt
@@ -22,6 +22,7 @@ class MainNet : Network() {
     override val dustRelayTxFee = 3000 // https://github.com/bitcoin/bitcoin/blob/c536dfbcb00fb15963bf5d507b7017c241718bf6/src/policy/policy.h#L50
 
     override var dnsSeeds = listOf(
+        "btc.unstoppable.money",
         "x5.seed.bitcoin.sipa.be",             // Pieter Wuille
         "x5.dnsseed.bluematt.me",              // Matt Corallo
         "x5.seed.bitcoinstats.com",            // Chris Decker

--- a/litecoinkit/src/main/kotlin/io/horizontalsystems/litecoinkit/MainNetLitecoin.kt
+++ b/litecoinkit/src/main/kotlin/io/horizontalsystems/litecoinkit/MainNetLitecoin.kt
@@ -21,6 +21,7 @@ class MainNetLitecoin : Network() {
     override val syncableFromApi = true
 
     override var dnsSeeds = listOf(
+        "ltc.unstoppable.money",
         "seed-a.litecoin.loshan.co.uk",  // Loshan - official, trusted
         "dnsseed.thrasher.io",           // Thrasher - official, trusted
         "dnsseed.litecoinpool.org",      // Litecoin Pool


### PR DESCRIPTION
* Add `btc.unstoppable.money` to Bitcoin MainNet DNS seeds
* Add `ltc.unstoppable.money` to Litecoin MainNet DNS seeds